### PR TITLE
Fix code editor update check

### DIFF
--- a/frontend/meta-configurator/src/components/code-editor/AceEditor.vue
+++ b/frontend/meta-configurator/src/components/code-editor/AceEditor.vue
@@ -40,7 +40,7 @@ onMounted(() => {
   watch(
     configData,
     newVal => {
-        updateEditorValue(newVal, currentPath.value);
+      updateEditorValue(newVal, currentPath.value);
     },
     {deep: true}
   );
@@ -48,14 +48,15 @@ onMounted(() => {
   watch(
     currentPath,
     newVal => {
-        updateSelectedPath(newVal, currentPath.value);
+      updateSelectedPath(newVal, currentPath.value);
     },
     {deep: true}
   );
 });
 
 function updateEditorValue(configData, currentPath: Path) {
-  const currEditorConfigObject = editor.value.getValue() != "" ? JSON.parse(editor.value.getValue()) : {};
+  const currEditorConfigObject =
+    editor.value.getValue() != '' ? JSON.parse(editor.value.getValue()) : {};
   if (!_.isEqual(currEditorConfigObject, configData)) {
     // Update value with new data and also update cursor position
     const newEditorContent = JSON.stringify(configData, null, 2);


### PR DESCRIPTION
When updating something in code editor, the update will be sent to store, and because code editor is subscribed to store, it will get its own change again.

Previously:
There is a check if incoming change stringified is equal to current JSON. If there is no change: don't send update and don't update cursor position.

Problem: because stringify(parse(incoming json string)) is compared with editor json string, equality check will think data is not equal and therefore update Code Editor value. This will reset cursor position and also remove the formatting change.

Solution: compare parse(incoming json string) with parse(editor json string). This way, only when actual content is different, will the data be seen as new.