### PR TITLE
fix: try fix semantic versioning

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,8 +1,8 @@
 name: Build and Deploy
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 permissions:
   contents: write
 jobs:
@@ -13,10 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Extract version from tag
+        run: echo "APP_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
       - name: Install and Build
         env:
           USE_META_CONFIGURATOR_BASE_PATH: true  # Set to true for GitHub Pages deployment
           VITE_FRONTEND_HOSTNAME: https://metaconfigurator.github.io/meta-configurator
+          VITE_APP_VERSION: ${{ env.APP_VERSION }}
         run: |
           cd meta_configurator
           npm ci

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -1,4 +1,4 @@
-name: Semantic Versioning
+name: Create Release Tag
 
 on:
   push:
@@ -9,40 +9,18 @@ permissions:
   contents: write
 
 jobs:
-  bump-version:
+  tag:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine next version (dry run)
-        id: tag
+      - name: Bump version and create tag
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: true
           default_bump: patch
-          # Conventional Commits mapping:
-          # fix: -> patch, feat: -> minor, BREAKING CHANGE -> major
           major_string_token: 'BREAKING CHANGE,!:'
           minor_string_token: 'feat:'
-          patch_string_token: 'fix:,perf:,refactor:'
-
-      - name: Update package.json version
-        if: steps.tag.outputs.new_tag != steps.tag.outputs.previous_tag
-        run: |
-          cd meta_configurator
-          npm version ${{ steps.tag.outputs.new_version }} --no-git-tag-version
-
-      - name: Commit version bump and create tag
-        if: steps.tag.outputs.new_tag != steps.tag.outputs.previous_tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add meta_configurator/package.json
-          git commit -m "chore: bump version to ${{ steps.tag.outputs.new_version }} [skip ci]"
-          git tag ${{ steps.tag.outputs.new_tag }}
-          git push
-          git push --tags
+          patch_string_token: 'fix:,perf:,refactor:,docs:,chore:,test:'

--- a/meta_configurator/vite.config.js
+++ b/meta_configurator/vite.config.js
@@ -16,7 +16,7 @@ const useMetaConfiguratorBasePath = process.env.USE_META_CONFIGURATOR_BASE_PATH 
 export default defineConfig({
   base: useMetaConfiguratorBasePath ? '/meta-configurator/' : '/',
   define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_VERSION__: JSON.stringify(process.env.VITE_APP_VERSION || pkg.version),
   },
   plugins: [vue(), vueJsx(),
 


### PR DESCRIPTION
<!-- Title must follow Conventional Commits: <type>: <Verb> <subject> — e.g. "feat: Add searchbar component" -->
<!-- Types: feat | fix | perf | refactor | docs | chore | test — see CONTRIBUTING.md -->

**What was done:**

New semantic versioning workflow: push to main leads to creation of new semantic version tag.
New semantic version tag leads to deployment of Github pages using the given version tag to show to the user in the About section.

**Why:**

Previous semantic versioning needed the GitHub bot to have write permissions on main without creating a PR (skipping branch protection), which was not desired.