### PR TITLE
895 refactor to use visitor pattern for json schema traversal

### DIFF
--- a/meta_configurator/src/schema/__tests__/detectSchemaFeatures.test.ts
+++ b/meta_configurator/src/schema/__tests__/detectSchemaFeatures.test.ts
@@ -1,0 +1,159 @@
+import {describe, expect, it, vi} from 'vitest';
+import {detectSchemaFeatures} from '@/schema/detectSchemaFeatures';
+import type {TopLevelSchema} from '@/schema/jsonSchemaType';
+
+vi.mock('@/dataformats/formatRegistry', () => ({
+  useDataConverter: () => ({
+    stringify: (data: any) => JSON.stringify(data),
+    parse: (data: string) => JSON.parse(data),
+  }),
+}));
+
+describe('detectSchemaFeatures', () => {
+  it('detects no features in a minimal schema', () => {
+    const schema: TopLevelSchema = {type: 'object'};
+    const features = detectSchemaFeatures(schema);
+
+    expect(features.composition).toBe(false);
+    expect(features.conditionals).toBe(false);
+    expect(features.defaultValues).toBe(false);
+    expect(features.exampleValues).toBe(false);
+    expect(features.enums).toBe(false);
+    expect(features.constants).toBe(false);
+    expect(features.multipleTypes).toBe(false);
+    expect(features.references).toBe(false);
+    expect(features.required).toBe(false);
+    expect(features.negation).toBe(false);
+    expect(features.booleanSchemas).toBe(false);
+    expect(features.descriptions).toBe(false);
+    expect(features.titles).toBe(false);
+    expect(features.externalReferences).toBe(false);
+  });
+
+  it('detects composition (allOf/anyOf/oneOf)', () => {
+    expect(detectSchemaFeatures({allOf: [{type: 'string'}]}).composition).toBe(true);
+    expect(detectSchemaFeatures({anyOf: [{type: 'string'}]}).composition).toBe(true);
+    expect(detectSchemaFeatures({oneOf: [{type: 'string'}, {type: 'number'}]}).composition).toBe(true);
+  });
+
+  it('detects conditionals (if/then/else)', () => {
+    expect(detectSchemaFeatures({if: {type: 'string'}, then: {minLength: 1}}).conditionals).toBe(true);
+    expect(detectSchemaFeatures({then: {minLength: 1}}).conditionals).toBe(true);
+    expect(detectSchemaFeatures({else: true}).conditionals).toBe(true);
+  });
+
+  it('detects default values including falsy ones', () => {
+    expect(detectSchemaFeatures({default: 'hello'}).defaultValues).toBe(true);
+    expect(detectSchemaFeatures({default: 0}).defaultValues).toBe(true);
+    expect(detectSchemaFeatures({default: false}).defaultValues).toBe(true);
+    expect(detectSchemaFeatures({default: null}).defaultValues).toBe(true);
+    expect(detectSchemaFeatures({default: ''}).defaultValues).toBe(true);
+  });
+
+  it('detects example values', () => {
+    expect(detectSchemaFeatures({examples: ['foo']}).exampleValues).toBe(true);
+  });
+
+  it('detects enums', () => {
+    expect(detectSchemaFeatures({enum: ['a', 'b']}).enums).toBe(true);
+  });
+
+  it('detects constants including falsy ones', () => {
+    expect(detectSchemaFeatures({const: 'foo'}).constants).toBe(true);
+    expect(detectSchemaFeatures({const: 0}).constants).toBe(true);
+    expect(detectSchemaFeatures({const: false}).constants).toBe(true);
+    expect(detectSchemaFeatures({const: null}).constants).toBe(true);
+  });
+
+  it('detects multiple types', () => {
+    expect(detectSchemaFeatures({type: ['string', 'null']}).multipleTypes).toBe(true);
+    expect(detectSchemaFeatures({type: 'string'}).multipleTypes).toBe(false);
+  });
+
+  it('detects $ref references', () => {
+    const schema: TopLevelSchema = {
+      type: 'object',
+      properties: {
+        foo: {$ref: '#/$defs/bar'},
+      },
+      $defs: {bar: {type: 'string'}},
+    };
+    expect(detectSchemaFeatures(schema).references).toBe(true);
+    expect(detectSchemaFeatures(schema).externalReferences).toBe(false);
+  });
+
+  it('detects external references', () => {
+    const schema: TopLevelSchema = {$ref: 'https://example.com/schema.json'};
+    expect(detectSchemaFeatures(schema).references).toBe(true);
+    expect(detectSchemaFeatures(schema).externalReferences).toBe(true);
+  });
+
+  it('detects required', () => {
+    expect(detectSchemaFeatures({type: 'object', required: ['name']}).required).toBe(true);
+  });
+
+  it('detects negation (not)', () => {
+    expect(detectSchemaFeatures({not: {type: 'string'}}).negation).toBe(true);
+  });
+
+  it('detects boolean schemas', () => {
+    const schema: TopLevelSchema = {
+      type: 'object',
+      properties: {
+        anything: true,
+        nothing: false,
+      },
+    } as TopLevelSchema;
+    expect(detectSchemaFeatures(schema).booleanSchemas).toBe(true);
+  });
+
+  it('detects descriptions', () => {
+    expect(detectSchemaFeatures({description: 'A schema'}).descriptions).toBe(true);
+  });
+
+  it('detects titles', () => {
+    expect(detectSchemaFeatures({title: 'My Schema'}).titles).toBe(true);
+  });
+
+  it('detects features in nested schemas', () => {
+    const schema: TopLevelSchema = {
+      type: 'object',
+      properties: {
+        nested: {
+          type: 'object',
+          properties: {
+            deep: {
+              enum: ['a', 'b'],
+              default: 'a',
+              description: 'A deep field',
+            },
+          },
+        },
+      },
+    };
+    const features = detectSchemaFeatures(schema);
+    expect(features.enums).toBe(true);
+    expect(features.defaultValues).toBe(true);
+    expect(features.descriptions).toBe(true);
+  });
+
+  it('detects features inside $defs', () => {
+    const schema: TopLevelSchema = {
+      $defs: {
+        myType: {
+          type: 'string',
+          title: 'My Type',
+          allOf: [{minLength: 1}],
+        },
+      },
+    };
+    const features = detectSchemaFeatures(schema);
+    expect(features.titles).toBe(true);
+    expect(features.composition).toBe(true);
+  });
+
+  it('does not fail on malformed schema in lenient mode (default)', () => {
+    const schema = {type: 123} as any;
+    expect(() => detectSchemaFeatures(schema)).not.toThrow();
+  });
+});

--- a/meta_configurator/src/schema/__tests__/detectSchemaFeatures.test.ts
+++ b/meta_configurator/src/schema/__tests__/detectSchemaFeatures.test.ts
@@ -33,11 +33,15 @@ describe('detectSchemaFeatures', () => {
   it('detects composition (allOf/anyOf/oneOf)', () => {
     expect(detectSchemaFeatures({allOf: [{type: 'string'}]}).composition).toBe(true);
     expect(detectSchemaFeatures({anyOf: [{type: 'string'}]}).composition).toBe(true);
-    expect(detectSchemaFeatures({oneOf: [{type: 'string'}, {type: 'number'}]}).composition).toBe(true);
+    expect(detectSchemaFeatures({oneOf: [{type: 'string'}, {type: 'number'}]}).composition).toBe(
+      true
+    );
   });
 
   it('detects conditionals (if/then/else)', () => {
-    expect(detectSchemaFeatures({if: {type: 'string'}, then: {minLength: 1}}).conditionals).toBe(true);
+    expect(detectSchemaFeatures({if: {type: 'string'}, then: {minLength: 1}}).conditionals).toBe(
+      true
+    );
     expect(detectSchemaFeatures({then: {minLength: 1}}).conditionals).toBe(true);
     expect(detectSchemaFeatures({else: true}).conditionals).toBe(true);
   });

--- a/meta_configurator/src/schema/__tests__/jsonSchemaVisitor.test.ts
+++ b/meta_configurator/src/schema/__tests__/jsonSchemaVisitor.test.ts
@@ -7,9 +7,21 @@ class RecordingVisitor extends JsonSchemaVisitor {
   readonly booleans: Array<{value: boolean; ctx: VisitorContext}> = [];
   readonly refs: Array<{ref: string; ctx: VisitorContext}> = [];
   readonly properties: Array<{name: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
-  readonly patternProperties: Array<{pattern: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
-  readonly subSchemaKeywords: Array<{keyword: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
-  readonly compositionals: Array<{keyword: string; schemas: JsonSchemaType | JsonSchemaType[]; ctx: VisitorContext}> = [];
+  readonly patternProperties: Array<{
+    pattern: string;
+    schema: JsonSchemaType;
+    ctx: VisitorContext;
+  }> = [];
+  readonly subSchemaKeywords: Array<{
+    keyword: string;
+    schema: JsonSchemaType;
+    ctx: VisitorContext;
+  }> = [];
+  readonly compositionals: Array<{
+    keyword: string;
+    schemas: JsonSchemaType | JsonSchemaType[];
+    ctx: VisitorContext;
+  }> = [];
   readonly conditionals: Array<{keyword: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
   readonly definitions: Array<{name: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
 
@@ -25,13 +37,25 @@ class RecordingVisitor extends JsonSchemaVisitor {
   protected visitProperty(name: string, schema: JsonSchemaType, ctx: VisitorContext): void {
     this.properties.push({name, schema, ctx});
   }
-  protected visitPatternProperty(pattern: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+  protected visitPatternProperty(
+    pattern: string,
+    schema: JsonSchemaType,
+    ctx: VisitorContext
+  ): void {
     this.patternProperties.push({pattern, schema, ctx});
   }
-  protected visitSubSchemaKeyword(keyword: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+  protected visitSubSchemaKeyword(
+    keyword: string,
+    schema: JsonSchemaType,
+    ctx: VisitorContext
+  ): void {
     this.subSchemaKeywords.push({keyword, schema, ctx});
   }
-  protected visitCompositional(keyword: string, schemas: JsonSchemaType | JsonSchemaType[], ctx: VisitorContext): void {
+  protected visitCompositional(
+    keyword: string,
+    schemas: JsonSchemaType | JsonSchemaType[],
+    ctx: VisitorContext
+  ): void {
     this.compositionals.push({keyword, schemas, ctx});
   }
   protected visitConditional(keyword: string, schema: JsonSchemaType, ctx: VisitorContext): void {

--- a/meta_configurator/src/schema/__tests__/jsonSchemaVisitor.test.ts
+++ b/meta_configurator/src/schema/__tests__/jsonSchemaVisitor.test.ts
@@ -1,0 +1,301 @@
+import {describe, expect, it} from 'vitest';
+import type {JsonSchemaObjectType, JsonSchemaType} from '@/schema/jsonSchemaType';
+import {JsonSchemaVisitor, type VisitorContext} from '@/schema/jsonSchemaVisitor';
+
+class RecordingVisitor extends JsonSchemaVisitor {
+  readonly schemas: Array<{schema: JsonSchemaObjectType; ctx: VisitorContext}> = [];
+  readonly booleans: Array<{value: boolean; ctx: VisitorContext}> = [];
+  readonly refs: Array<{ref: string; ctx: VisitorContext}> = [];
+  readonly properties: Array<{name: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
+  readonly patternProperties: Array<{pattern: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
+  readonly subSchemaKeywords: Array<{keyword: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
+  readonly compositionals: Array<{keyword: string; schemas: JsonSchemaType | JsonSchemaType[]; ctx: VisitorContext}> = [];
+  readonly conditionals: Array<{keyword: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
+  readonly definitions: Array<{name: string; schema: JsonSchemaType; ctx: VisitorContext}> = [];
+
+  protected visitSchema(schema: JsonSchemaObjectType, ctx: VisitorContext): void {
+    this.schemas.push({schema, ctx});
+  }
+  protected visitBooleanSchema(value: boolean, ctx: VisitorContext): void {
+    this.booleans.push({value, ctx});
+  }
+  protected visitRef(ref: string, ctx: VisitorContext): void {
+    this.refs.push({ref, ctx});
+  }
+  protected visitProperty(name: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.properties.push({name, schema, ctx});
+  }
+  protected visitPatternProperty(pattern: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.patternProperties.push({pattern, schema, ctx});
+  }
+  protected visitSubSchemaKeyword(keyword: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.subSchemaKeywords.push({keyword, schema, ctx});
+  }
+  protected visitCompositional(keyword: string, schemas: JsonSchemaType | JsonSchemaType[], ctx: VisitorContext): void {
+    this.compositionals.push({keyword, schemas, ctx});
+  }
+  protected visitConditional(keyword: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.conditionals.push({keyword, schema, ctx});
+  }
+  protected visitDefinition(name: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.definitions.push({name, schema, ctx});
+  }
+}
+
+describe('JsonSchemaVisitor', () => {
+  it('visits a simple object schema', () => {
+    const visitor = new RecordingVisitor();
+    const schema = {type: 'object', title: 'Root'};
+    visitor.traverse(schema);
+
+    expect(visitor.schemas).toHaveLength(1);
+    expect(visitor.schemas[0].schema).toBe(schema);
+    expect(visitor.schemas[0].ctx.depth).toBe(0);
+    expect(visitor.schemas[0].ctx.path).toEqual([]);
+    expect(visitor.schemas[0].ctx.parentKind).toBeNull();
+  });
+
+  it('visits a boolean schema', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse(true);
+
+    expect(visitor.booleans).toHaveLength(1);
+    expect(visitor.booleans[0].value).toBe(true);
+  });
+
+  it('visits properties with correct context', () => {
+    const visitor = new RecordingVisitor();
+    const schema = {
+      type: 'object',
+      properties: {
+        name: {type: 'string'},
+        age: {type: 'number'},
+      },
+    };
+    visitor.traverse(schema);
+
+    expect(visitor.properties).toHaveLength(2);
+    expect(visitor.properties[0].name).toBe('name');
+    expect(visitor.properties[0].ctx.path).toEqual(['properties', 'name']);
+    expect(visitor.properties[0].ctx.parentKind).toBe('property');
+    expect(visitor.properties[1].name).toBe('age');
+    expect(visitor.properties[1].ctx.path).toEqual(['properties', 'age']);
+  });
+
+  it('visits patternProperties', () => {
+    const visitor = new RecordingVisitor();
+    const schema = {
+      type: 'object',
+      patternProperties: {
+        '^S_': {type: 'string'},
+      },
+    };
+    visitor.traverse(schema);
+
+    expect(visitor.patternProperties).toHaveLength(1);
+    expect(visitor.patternProperties[0].pattern).toBe('^S_');
+    expect(visitor.patternProperties[0].ctx.parentKind).toBe('pattern');
+    expect(visitor.patternProperties[0].ctx.path).toEqual(['patternProperties', '^S_']);
+  });
+
+  it('visits $ref', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({$ref: '#/$defs/foo'});
+
+    expect(visitor.refs).toHaveLength(1);
+    expect(visitor.refs[0].ref).toBe('#/$defs/foo');
+  });
+
+  it('visits allOf, anyOf, oneOf', () => {
+    const visitor = new RecordingVisitor();
+    const schema = {
+      allOf: [{type: 'object'}],
+      anyOf: [{type: 'string'}, {type: 'number'}],
+      oneOf: [{type: 'boolean'}],
+    };
+    visitor.traverse(schema);
+
+    const keywords = visitor.compositionals.map(c => c.keyword);
+    expect(keywords).toContain('allOf');
+    expect(keywords).toContain('anyOf');
+    expect(keywords).toContain('oneOf');
+  });
+
+  it('visits not', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({not: {type: 'string'}});
+
+    expect(visitor.compositionals).toHaveLength(1);
+    expect(visitor.compositionals[0].keyword).toBe('not');
+  });
+
+  it('visits if/then/else', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({
+      if: {type: 'string'},
+      then: {minLength: 1},
+      else: true,
+    });
+
+    const conditionalKeywords = visitor.conditionals.map(c => c.keyword);
+    expect(conditionalKeywords).toContain('if');
+    expect(conditionalKeywords).toContain('then');
+    expect(conditionalKeywords).toContain('else');
+    expect(visitor.conditionals[2].schema).toBe(true);
+  });
+
+  it('visits $defs', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({
+      $defs: {
+        foo: {type: 'string'},
+        bar: {type: 'number'},
+      },
+    });
+
+    expect(visitor.definitions).toHaveLength(2);
+    const names = visitor.definitions.map(d => d.name);
+    expect(names).toContain('foo');
+    expect(names).toContain('bar');
+    expect(visitor.definitions[0].ctx.parentKind).toBe('definition');
+    expect(visitor.definitions[0].ctx.path).toEqual(['$defs', 'foo']);
+  });
+
+  it('visits legacy definitions keyword', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({definitions: {myDef: {type: 'object'}}});
+
+    expect(visitor.definitions).toHaveLength(1);
+    expect(visitor.definitions[0].name).toBe('myDef');
+    expect(visitor.definitions[0].ctx.path).toEqual(['definitions', 'myDef']);
+  });
+
+  it('visits items as single schema', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({type: 'array', items: {type: 'string'}});
+
+    expect(visitor.subSchemaKeywords).toHaveLength(1);
+    expect(visitor.subSchemaKeywords[0].keyword).toBe('items');
+    expect(visitor.subSchemaKeywords[0].ctx.path).toEqual(['items']);
+  });
+
+  it('visits items as array (tuple)', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({type: 'array', items: [{type: 'string'}, {type: 'number'}]});
+
+    expect(visitor.subSchemaKeywords).toHaveLength(2);
+    expect(visitor.subSchemaKeywords[0].ctx.path).toEqual(['items', 0]);
+    expect(visitor.subSchemaKeywords[1].ctx.path).toEqual(['items', 1]);
+  });
+
+  it('visits additionalProperties', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({type: 'object', additionalProperties: {type: 'string'}});
+
+    expect(visitor.subSchemaKeywords.some(k => k.keyword === 'additionalProperties')).toBe(true);
+  });
+
+  it('tracks depth correctly', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({
+      type: 'object',
+      properties: {
+        child: {type: 'string'},
+      },
+    });
+
+    const rootSchema = visitor.schemas.find(s => s.ctx.depth === 0);
+    const childSchema = visitor.schemas.find(s => s.ctx.depth === 1);
+    expect(rootSchema).toBeDefined();
+    expect(childSchema).toBeDefined();
+    expect(childSchema!.ctx.path).toEqual(['properties', 'child']);
+  });
+
+  it('visits deeply nested schemas', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({
+      type: 'object',
+      properties: {
+        outer: {
+          type: 'object',
+          properties: {
+            inner: {type: 'string'},
+          },
+        },
+      },
+    });
+
+    const innerProp = visitor.properties.find(p => p.name === 'inner');
+    expect(innerProp).toBeDefined();
+    expect(innerProp!.ctx.path).toEqual(['properties', 'outer', 'properties', 'inner']);
+    expect(innerProp!.ctx.depth).toBe(2);
+  });
+
+  it('strict mode throws on invalid keyword value', () => {
+    const visitor = new RecordingVisitor(true);
+    expect(() => visitor.traverse({type: 123 as any})).toThrow(TypeError);
+  });
+
+  it('lenient mode skips invalid keyword value', () => {
+    const visitor = new RecordingVisitor(false);
+    expect(() => visitor.traverse({type: 123 as any})).not.toThrow();
+  });
+
+  it('strict mode throws on non-schema value', () => {
+    const visitor = new RecordingVisitor(true);
+    expect(() => visitor.traverse('not a schema' as any)).toThrow(TypeError);
+  });
+
+  it('lenient mode skips non-schema value', () => {
+    const visitor = new RecordingVisitor(false);
+    expect(() => visitor.traverse('not a schema' as any)).not.toThrow();
+  });
+
+  it('visits dependentSchemas as definitions', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({
+      dependentSchemas: {
+        credit_card: {required: ['billing_address']},
+      },
+    });
+
+    expect(visitor.definitions).toHaveLength(1);
+    expect(visitor.definitions[0].name).toBe('credit_card');
+    expect(visitor.definitions[0].ctx.path).toEqual(['dependentSchemas', 'credit_card']);
+  });
+
+  it('skips array-valued dependencies, visits schema-valued ones', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({
+      dependencies: {
+        name: ['address'],
+        address: {required: ['city']},
+      },
+    } as any);
+
+    expect(visitor.definitions).toHaveLength(1);
+    expect(visitor.definitions[0].name).toBe('address');
+  });
+
+  it('visits $dynamicRef and $recursiveRef', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({$dynamicRef: '#myAnchor'} as any);
+    expect(visitor.refs).toHaveLength(1);
+    expect(visitor.refs[0].ref).toBe('#myAnchor');
+
+    const visitor2 = new RecordingVisitor();
+    visitor2.traverse({$recursiveRef: '#'} as any);
+    expect(visitor2.refs).toHaveLength(1);
+    expect(visitor2.refs[0].ref).toBe('#');
+  });
+
+  it('handles prefixItems', () => {
+    const visitor = new RecordingVisitor();
+    visitor.traverse({type: 'array', prefixItems: [{type: 'string'}, {type: 'number'}]} as any);
+
+    const prefixItemKeywords = visitor.subSchemaKeywords.filter(k => k.keyword === 'prefixItems');
+    expect(prefixItemKeywords).toHaveLength(2);
+    expect(prefixItemKeywords[0].ctx.path).toEqual(['prefixItems', 0]);
+    expect(prefixItemKeywords[1].ctx.path).toEqual(['prefixItems', 1]);
+  });
+});

--- a/meta_configurator/src/schema/detectSchemaFeatures.ts
+++ b/meta_configurator/src/schema/detectSchemaFeatures.ts
@@ -1,5 +1,6 @@
-import type {JsonSchemaObjectType, JsonSchemaType, TopLevelSchema} from '@/schema/jsonSchemaType';
+import type {JsonSchemaObjectType, TopLevelSchema} from '@/schema/jsonSchemaType';
 import {isExternalRef} from '@/schema/externalReferences.ts';
+import {JsonSchemaVisitor} from '@/schema/jsonSchemaVisitor.ts';
 
 export type SchemaFeatures = {
   composition: boolean;
@@ -19,10 +20,10 @@ export type SchemaFeatures = {
   // on purpose, we currently do not track whether it uses constraints (e.g., maxLength, minLength, etc.) because there are so many of them and for our use case we do not need to know about them
 };
 
-export function detectSchemaFeatures(jsonSchema: TopLevelSchema): SchemaFeatures {
-  const features: SchemaFeatures = {
-    composition: false, // oneOf, anyOf, allOf
-    conditionals: false, // if, then, else
+class SchemaFeaturesVisitor extends JsonSchemaVisitor {
+  readonly features: SchemaFeatures = {
+    composition: false,
+    conditionals: false,
     defaultValues: false,
     exampleValues: false,
     enums: false,
@@ -31,151 +32,38 @@ export function detectSchemaFeatures(jsonSchema: TopLevelSchema): SchemaFeatures
     references: false,
     required: false,
     negation: false,
-    booleanSchemas: false, // when a sub-schema is simply true or false instead of an object
+    booleanSchemas: false,
     descriptions: false,
     titles: false,
-    externalReferences: false, // whether the schema contains $refs that point to external schemas (i.e., not starting with #)
+    externalReferences: false,
   };
 
-  // detect features for root level schema
-  detectSubSchemaFeatures(jsonSchema, features);
-
-  // detect features for all $defs and definitions
-  if (jsonSchema.$defs) {
-    for (const key in jsonSchema.$defs) {
-      detectSubSchemaFeatures(jsonSchema.$defs[key], features);
-    }
-  }
-  if (jsonSchema.definitions) {
-    for (const key in jsonSchema.definitions) {
-      detectSubSchemaFeatures(jsonSchema.definitions[key], features);
-    }
+  protected visitBooleanSchema(): void {
+    this.features.booleanSchemas = true;
   }
 
-  return features;
-}
+  protected visitSchema(schema: JsonSchemaObjectType): void {
+    if (schema.allOf || schema.anyOf || schema.oneOf) this.features.composition = true;
+    if (schema.if !== undefined || schema.then !== undefined || schema.else !== undefined) this.features.conditionals = true;
+    if ('default' in schema) this.features.defaultValues = true;
+    if (schema.examples) this.features.exampleValues = true;
+    if (schema.enum) this.features.enums = true;
+    if ('const' in schema) this.features.constants = true;
+    if (Array.isArray(schema.type)) this.features.multipleTypes = true;
+    if (schema.required) this.features.required = true;
+    if (schema.not !== undefined) this.features.negation = true;
+    if (schema.description) this.features.descriptions = true;
+    if (schema.title) this.features.titles = true;
+  }
 
-function detectSubSchemaPropertiesFeatures(subSchema: JsonSchemaType, features: SchemaFeatures) {
-  // the sub schema will be either true, false or a dictionary of keys that map to a sub schema
-  // this function will be called for properties, patternProperties each
-  if (typeof subSchema === 'object' && !Array.isArray(subSchema)) {
-    for (const key in subSchema) {
-      detectSubSchemaFeatures(subSchema[key], features);
-    }
-  } else if (subSchema === true || subSchema === false) {
-    features.booleanSchemas = true;
+  protected visitRef(ref: string): void {
+    this.features.references = true;
+    if (isExternalRef(ref)) this.features.externalReferences = true;
   }
 }
 
-function detectSubSchemaFeatures(subSchema: JsonSchemaType, features: SchemaFeatures) {
-  if (subSchema == true || subSchema == false) {
-    features.booleanSchemas = true;
-  } else {
-    detectSubObjectSchemaFeatures(subSchema, features);
-  }
-}
-
-function detectSubObjectSchemaFeatures(subSchema: JsonSchemaObjectType, features: SchemaFeatures) {
-  // Check for composition
-  if ('oneOf' in subSchema || 'anyOf' in subSchema || 'allOf' in subSchema) {
-    features.composition = true;
-
-    if ('oneOf' in subSchema) {
-      detectSchemaFeatures(subSchema.oneOf);
-    }
-    if ('anyOf' in subSchema) {
-      detectSchemaFeatures(subSchema.anyOf);
-    }
-    if ('allOf' in subSchema) {
-      detectSchemaFeatures(subSchema.allOf);
-    }
-  }
-
-  // Check for conditionals
-  if ('if' in subSchema || 'then' in subSchema || 'else' in subSchema) {
-    features.conditionals = true;
-
-    if ('if' in subSchema) {
-      detectSubSchemaFeatures(subSchema.if, features);
-    }
-    if ('then' in subSchema) {
-      detectSubSchemaFeatures(subSchema.then, features);
-    }
-    if ('else' in subSchema) {
-      detectSubSchemaFeatures(subSchema.else, features);
-    }
-  }
-
-  // Check for default values
-  if (subSchema.default) {
-    features.defaultValues = true;
-  }
-
-  // Check for example values
-  if (subSchema.examples) {
-    features.exampleValues = true;
-  }
-
-  // Check for enums
-  if (subSchema.enum) {
-    features.enums = true;
-  }
-
-  // Check for constants
-  if (subSchema.const) {
-    features.constants = true;
-  }
-
-  // Check for multiple types
-  if (Array.isArray(subSchema.type)) {
-    features.multipleTypes = true;
-  }
-
-  // Check for references
-  if (subSchema.$ref) {
-    features.references = true;
-    if (isExternalRef(subSchema.$ref)) {
-      features.externalReferences = true;
-    }
-  }
-
-  // Check for required properties
-  if (subSchema.required) {
-    features.required = true;
-  }
-
-  // Check for negation
-  if (subSchema.not) {
-    features.negation = true;
-  }
-
-  // Check for descriptions
-  if (subSchema.description) {
-    features.descriptions = true;
-  }
-
-  // Check for titles
-  if (subSchema.title) {
-    features.titles = true;
-  }
-
-  // recursively check for features in properties and patternProperties and additionalProperties
-  if ('properties' in subSchema) {
-    detectSubSchemaPropertiesFeatures(subSchema.properties, features);
-  }
-  if ('patternProperties' in subSchema) {
-    detectSubSchemaPropertiesFeatures(subSchema.patternProperties, features);
-  }
-  if ('additionalProperties' in subSchema) {
-    detectSubSchemaFeatures(subSchema.additionalProperties, features);
-  }
-
-  // recursively check for items in case of arrays
-  if (Array.isArray(subSchema.items)) {
-    subSchema.items.forEach(item => {
-      detectSubSchemaFeatures(item, features);
-    });
-  } else if (subSchema.items) {
-    detectSubSchemaFeatures(subSchema.items, features);
-  }
+export function detectSchemaFeatures(jsonSchema: TopLevelSchema): SchemaFeatures {
+  const visitor = new SchemaFeaturesVisitor(false);
+  visitor.traverse(jsonSchema);
+  return visitor.features;
 }

--- a/meta_configurator/src/schema/detectSchemaFeatures.ts
+++ b/meta_configurator/src/schema/detectSchemaFeatures.ts
@@ -44,7 +44,8 @@ class SchemaFeaturesVisitor extends JsonSchemaVisitor {
 
   protected visitSchema(schema: JsonSchemaObjectType): void {
     if (schema.allOf || schema.anyOf || schema.oneOf) this.features.composition = true;
-    if (schema.if !== undefined || schema.then !== undefined || schema.else !== undefined) this.features.conditionals = true;
+    if (schema.if !== undefined || schema.then !== undefined || schema.else !== undefined)
+      this.features.conditionals = true;
     if ('default' in schema) this.features.defaultValues = true;
     if (schema.examples) this.features.exampleValues = true;
     if (schema.enum) this.features.enums = true;

--- a/meta_configurator/src/schema/graph-representation/__tests__/schemaGraphConstructorBasicFeatures.test.ts
+++ b/meta_configurator/src/schema/graph-representation/__tests__/schemaGraphConstructorBasicFeatures.test.ts
@@ -1,12 +1,11 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import type {Path} from '@/utility/path';
 import type {TopLevelSchema} from '@/schema/jsonSchemaType';
 import {EdgeType, SchemaGraph, SchemaObjectNodeData} from '../schemaGraphTypes';
 import {
   generateAttributeEdges,
   generateObjectAttributes,
   generateObjectFallbackDisplayName,
-  identifyObjects,
+  identifyAllObjects,
   isSchemaThatDeservesANode,
 } from '../schemaGraphConstructor';
 
@@ -65,12 +64,7 @@ describe('test schema graph constructor with objects and attributes, without adv
   let defs: Map<string, SchemaObjectNodeData>;
 
   beforeEach(() => {
-    currentPath = [];
-    defs = new Map();
-
-    identifyObjects(currentPath, schema, defs, false, schema);
-    // @ts-ignore
-    identifyObjects(['$defs', 'person'], schema.$defs.person, defs);
+    defs = identifyAllObjects(schema);
   });
 
   it('identify objects', () => {

--- a/meta_configurator/src/schema/graph-representation/__tests__/schemaGraphConstructorComposition.test.ts
+++ b/meta_configurator/src/schema/graph-representation/__tests__/schemaGraphConstructorComposition.test.ts
@@ -1,5 +1,4 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import type {Path} from '@/utility/path';
 import type {TopLevelSchema} from '@/schema/jsonSchemaType';
 import {EdgeType, SchemaGraph, SchemaObjectNodeData} from '../schemaGraphTypes';
 import {
@@ -7,7 +6,7 @@ import {
   generateObjectAttributes,
   generateObjectSpecialPropertyEdges,
   generateObjectFallbackDisplayName,
-  identifyObjects,
+  identifyAllObjects,
   isObjectSchema,
   isSchemaThatDeservesANode,
 } from '../schemaGraphConstructor';
@@ -20,7 +19,6 @@ vi.mock('@/dataformats/formatRegistry', () => ({
 }));
 
 describe('test schema graph constructor with objects and compositional keywords', () => {
-  let currentPath: Path;
   let schema: TopLevelSchema = {
     type: 'object',
     required: ['propertyObject'],
@@ -115,14 +113,7 @@ describe('test schema graph constructor with objects and compositional keywords'
   let defs: Map<string, SchemaObjectNodeData>;
 
   beforeEach(() => {
-    currentPath = [];
-    defs = new Map();
-
-    identifyObjects(currentPath, schema, defs, false, schema);
-    // @ts-ignore
-    for (const [key, value] of Object.entries(schema.$defs)) {
-      identifyObjects(['$defs', key], value, defs, true, schema);
-    }
+    defs = identifyAllObjects(schema);
   });
 
   it('identify objects', () => {

--- a/meta_configurator/src/schema/graph-representation/__tests__/schemaGraphConstructorConditionals.test.ts
+++ b/meta_configurator/src/schema/graph-representation/__tests__/schemaGraphConstructorConditionals.test.ts
@@ -1,12 +1,11 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import type {Path} from '@/utility/path';
 import type {TopLevelSchema} from '@/schema/jsonSchemaType';
 import {EdgeType, SchemaGraph, SchemaObjectNodeData} from '../schemaGraphTypes';
 import {
   generateObjectAttributes,
   generateObjectSpecialPropertyEdges,
   generateObjectFallbackDisplayName,
-  identifyObjects,
+  identifyAllObjects,
   isObjectSchema,
   populateGraph,
   trimGraph,
@@ -20,7 +19,6 @@ vi.mock('@/dataformats/formatRegistry', () => ({
 }));
 
 describe('test schema graph constructor with conditionals', () => {
-  let currentPath: Path;
   let schema: TopLevelSchema = {
     type: 'object',
     required: ['propertyObject'],
@@ -66,14 +64,7 @@ describe('test schema graph constructor with conditionals', () => {
   let defs: Map<string, SchemaObjectNodeData>;
 
   beforeEach(() => {
-    currentPath = [];
-    defs = new Map();
-
-    identifyObjects(currentPath, schema, defs, false, schema);
-    // @ts-ignore
-    for (const [key, value] of Object.entries(schema.$defs)) {
-      identifyObjects(['$defs', key], value, defs, true, schema);
-    }
+    defs = identifyAllObjects(schema);
   });
 
   it('identify objects', () => {

--- a/meta_configurator/src/schema/graph-representation/__tests__/schemaGraphConstructorEnum.test.ts
+++ b/meta_configurator/src/schema/graph-representation/__tests__/schemaGraphConstructorEnum.test.ts
@@ -1,11 +1,10 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import type {Path} from '@/utility/path';
 import type {TopLevelSchema} from '@/schema/jsonSchemaType';
 import {EdgeType, SchemaEnumNodeData, SchemaGraph, SchemaObjectNodeData} from '../schemaGraphTypes';
 import {
   generateAttributeEdges,
   generateObjectAttributes,
-  identifyObjects,
+  identifyAllObjects,
   populateGraph,
   trimNodeChildren,
 } from '../schemaGraphConstructor';
@@ -30,7 +29,6 @@ vi.mock('@/dataformats/formatRegistry', () => ({
 }));
 
 describe('test schema graph constructor with objects and attributes with enums', () => {
-  let currentPath: Path;
   let schema: TopLevelSchema = {
     type: 'object',
     $defs: {
@@ -64,13 +62,7 @@ describe('test schema graph constructor with objects and attributes with enums',
   let defs: Map<string, SchemaObjectNodeData>;
 
   beforeEach(() => {
-    currentPath = [];
-    defs = new Map();
-    identifyObjects(currentPath, schema, defs, false, schema);
-    // @ts-ignore
-    for (const [key, value] of Object.entries(schema.$defs)) {
-      identifyObjects(['$defs', key], value, defs, true, schema);
-    }
+    defs = identifyAllObjects(schema);
   });
 
   it('identify objects', () => {

--- a/meta_configurator/src/schema/graph-representation/schemaGraphConstructor.ts
+++ b/meta_configurator/src/schema/graph-representation/schemaGraphConstructor.ts
@@ -82,7 +82,12 @@ class IdentifyObjectsVisitor extends JsonSchemaVisitor {
     if (typeof schema === 'object' && schema !== null) {
       this.defs.set(
         pathToString(path),
-        generateInitialNode(path, hasUserDefinedName, schema as JsonSchemaObjectType, this.rootSchema)
+        generateInitialNode(
+          path,
+          hasUserDefinedName,
+          schema as JsonSchemaObjectType,
+          this.rootSchema
+        )
       );
     }
   }
@@ -97,7 +102,11 @@ class IdentifyObjectsVisitor extends JsonSchemaVisitor {
     this.addNode(schema, ctx.path as Path, true);
   }
 
-  protected visitPatternProperty(_pattern: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+  protected visitPatternProperty(
+    _pattern: string,
+    schema: JsonSchemaType,
+    ctx: VisitorContext
+  ): void {
     this.addNode(schema, ctx.path as Path, true);
   }
 
@@ -105,7 +114,11 @@ class IdentifyObjectsVisitor extends JsonSchemaVisitor {
     this.addNode(schema, ctx.path as Path, true);
   }
 
-  protected visitCompositional(keyword: string, schemas: JsonSchemaType | JsonSchemaType[], ctx: VisitorContext): void {
+  protected visitCompositional(
+    keyword: string,
+    schemas: JsonSchemaType | JsonSchemaType[],
+    ctx: VisitorContext
+  ): void {
     if (keyword !== 'not' && Array.isArray(schemas)) {
       schemas.forEach((schema, i) => {
         this.addNode(schema, [...ctx.path, keyword, i] as Path, false);
@@ -117,7 +130,11 @@ class IdentifyObjectsVisitor extends JsonSchemaVisitor {
     this.addNode(schema, ctx.path as Path, false);
   }
 
-  protected visitSubSchemaKeyword(keyword: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+  protected visitSubSchemaKeyword(
+    keyword: string,
+    schema: JsonSchemaType,
+    ctx: VisitorContext
+  ): void {
     if (keyword === 'items' || keyword === 'additionalProperties') {
       this.addNode(schema, ctx.path as Path, false);
     }

--- a/meta_configurator/src/schema/graph-representation/schemaGraphConstructor.ts
+++ b/meta_configurator/src/schema/graph-representation/schemaGraphConstructor.ts
@@ -22,6 +22,7 @@ import {
 } from '@/schema/graph-representation/schemaGraphTypes';
 import {useErrorService} from '@/utility/errorServiceInstance';
 import {isExternalRef} from '@/schema/externalReferences.ts';
+import {JsonSchemaVisitor, type VisitorContext} from '@/schema/jsonSchemaVisitor.ts';
 
 const settings = useSettings();
 
@@ -70,122 +71,69 @@ export function populateGraph(
   }
 }
 
-export function identifyAllObjects(rootSchema: TopLevelSchema): Map<string, SchemaObjectNodeData> {
-  const objectDefs = new Map<string, SchemaObjectNodeData>();
-  identifyObjects([], rootSchema, objectDefs, false, rootSchema);
+class IdentifyObjectsVisitor extends JsonSchemaVisitor {
+  readonly defs = new Map<string, SchemaElementData>();
 
-  if (rootSchema.$defs) {
-    for (const [key, value] of Object.entries(rootSchema.$defs)) {
-      identifyObjects(['$defs', key], value, objectDefs, true, rootSchema);
-    }
-  }
-  if (rootSchema.definitions) {
-    for (const [key, value] of Object.entries(rootSchema.definitions)) {
-      identifyObjects(['definitions', key], value, objectDefs, true, rootSchema);
-    }
+  constructor(private readonly rootSchema: TopLevelSchema) {
+    super();
   }
 
-  return objectDefs;
-}
-
-export function identifyObjects(
-  currentPath: Path,
-  schema: JsonSchemaType,
-  defs: Map<string, SchemaElementData>,
-  hasUserDefinedName: boolean,
-  rootSchema: TopLevelSchema
-) {
-  if (schema === true || schema === false) {
-    return;
-  }
-
-  // It can be that simple types, such as strings with enum constraint, have their own definition.
-  // We allow generating a node for this, so it can be referred to by other objects.
-  // But we do not visualize those nodes for simple types.
-  defs.set(
-    pathToString(currentPath),
-    generateInitialNode(currentPath, hasUserDefinedName, schema, rootSchema)
-  );
-
-  if (schema.properties) {
-    for (const [key, value] of Object.entries(schema.properties)) {
-      if (typeof value === 'object') {
-        const childPath = [...currentPath, 'properties', key];
-        identifyObjects(childPath, value, defs, true, rootSchema);
-      }
-    }
-  }
-  if (schema.patternProperties) {
-    for (const [key, value] of Object.entries(schema.patternProperties)) {
-      if (typeof value === 'object') {
-        const childPath = [...currentPath, 'patternProperties', key];
-        identifyObjects(childPath, value, defs, true, rootSchema);
-      }
-    }
-  }
-  if (schema.items) {
-    if (typeof schema.items === 'object') {
-      const childPath = [...currentPath, 'items'];
-      identifyObjects(childPath, schema.items, defs, false, rootSchema);
-    }
-  }
-
-  if (schema.oneOf) {
-    for (const [index, value] of schema.oneOf.entries()) {
-      if (typeof value === 'object') {
-        const childPath = [...currentPath, 'oneOf', index];
-        identifyObjects(childPath, value, defs, false, rootSchema);
-      }
-    }
-  }
-  if (schema.anyOf) {
-    for (const [index, value] of schema.anyOf.entries()) {
-      if (typeof value === 'object') {
-        const childPath = [...currentPath, 'anyOf', index];
-        identifyObjects(childPath, value, defs, false, rootSchema);
-      }
-    }
-  }
-  if (schema.allOf) {
-    for (const [index, value] of schema.allOf.entries()) {
-      if (typeof value === 'object') {
-        const childPath = [...currentPath, 'allOf', index];
-        identifyObjects(childPath, value, defs, false, rootSchema);
-      }
-    }
-  }
-  if (schema.if) {
-    if (typeof schema.if === 'object') {
-      identifyObjects([...currentPath, 'if'], schema.if, defs, false, rootSchema);
-    }
-  }
-  if (schema.then) {
-    if (typeof schema.then === 'object') {
-      identifyObjects([...currentPath, 'then'], schema.then, defs, false, rootSchema);
-    }
-  }
-  if (schema.else) {
-    if (typeof schema.else === 'object') {
-      identifyObjects([...currentPath, 'else'], schema.else, defs, false, rootSchema);
-    }
-  }
-  if (schema.additionalProperties) {
-    if (typeof schema.additionalProperties === 'object') {
-      identifyObjects(
-        [...currentPath, 'additionalProperties'],
-        schema.additionalProperties,
-        defs,
-        false,
-        rootSchema
+  private addNode(schema: JsonSchemaType, path: Path, hasUserDefinedName: boolean): void {
+    if (typeof schema === 'object' && schema !== null) {
+      this.defs.set(
+        pathToString(path),
+        generateInitialNode(path, hasUserDefinedName, schema as JsonSchemaObjectType, this.rootSchema)
       );
     }
   }
-  if (schema.$ref && isExternalRef(schema.$ref)) {
-    defs.set(
-      schema.$ref,
-      new SchemaExternalReferenceNodeData(schema.$ref, [...currentPath, '$ref'])
-    );
+
+  protected visitSchema(schema: JsonSchemaObjectType, ctx: VisitorContext): void {
+    if (ctx.depth === 0) {
+      this.addNode(schema, [] as Path, false);
+    }
   }
+
+  protected visitProperty(_name: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.addNode(schema, ctx.path as Path, true);
+  }
+
+  protected visitPatternProperty(_pattern: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.addNode(schema, ctx.path as Path, true);
+  }
+
+  protected visitDefinition(_name: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.addNode(schema, ctx.path as Path, true);
+  }
+
+  protected visitCompositional(keyword: string, schemas: JsonSchemaType | JsonSchemaType[], ctx: VisitorContext): void {
+    if (keyword !== 'not' && Array.isArray(schemas)) {
+      schemas.forEach((schema, i) => {
+        this.addNode(schema, [...ctx.path, keyword, i] as Path, false);
+      });
+    }
+  }
+
+  protected visitConditional(_keyword: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    this.addNode(schema, ctx.path as Path, false);
+  }
+
+  protected visitSubSchemaKeyword(keyword: string, schema: JsonSchemaType, ctx: VisitorContext): void {
+    if (keyword === 'items' || keyword === 'additionalProperties') {
+      this.addNode(schema, ctx.path as Path, false);
+    }
+  }
+
+  protected visitRef(ref: string, ctx: VisitorContext): void {
+    if (isExternalRef(ref)) {
+      this.defs.set(ref, new SchemaExternalReferenceNodeData(ref, [...ctx.path, '$ref'] as Path));
+    }
+  }
+}
+
+export function identifyAllObjects(rootSchema: TopLevelSchema): Map<string, SchemaObjectNodeData> {
+  const visitor = new IdentifyObjectsVisitor(rootSchema);
+  visitor.traverse(rootSchema);
+  return visitor.defs as unknown as Map<string, SchemaObjectNodeData>;
 }
 
 function generateInitialNode(

--- a/meta_configurator/src/schema/jsonSchemaVisitor.ts
+++ b/meta_configurator/src/schema/jsonSchemaVisitor.ts
@@ -45,15 +45,42 @@ export abstract class JsonSchemaVisitor {
   protected visitBooleanSchema(_value: boolean, _context: VisitorContext): void {}
   protected visitRef(_ref: string, _context: VisitorContext): void {}
   protected visitProperty(_name: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
-  protected visitPatternProperty(_pattern: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
-  protected visitSubSchemaKeyword(_keyword: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
-  protected visitCompositional(_keyword: string, _schemas: JsonSchemaType | JsonSchemaType[], _context: VisitorContext): void {}
-  protected visitConditional(_keyword: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
-  protected visitDefinition(_name: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
+  protected visitPatternProperty(
+    _pattern: string,
+    _schema: JsonSchemaType,
+    _context: VisitorContext
+  ): void {}
+  protected visitSubSchemaKeyword(
+    _keyword: string,
+    _schema: JsonSchemaType,
+    _context: VisitorContext
+  ): void {}
+  protected visitCompositional(
+    _keyword: string,
+    _schemas: JsonSchemaType | JsonSchemaType[],
+    _context: VisitorContext
+  ): void {}
+  protected visitConditional(
+    _keyword: string,
+    _schema: JsonSchemaType,
+    _context: VisitorContext
+  ): void {}
+  protected visitDefinition(
+    _name: string,
+    _schema: JsonSchemaType,
+    _context: VisitorContext
+  ): void {}
 
-  private invalid(keyword: string, expected: string, path: readonly (string | number)[], actual: unknown): false {
+  private invalid(
+    keyword: string,
+    expected: string,
+    path: readonly (string | number)[],
+    actual: unknown
+  ): false {
     if (this.strict) {
-      throw new TypeError(`[/${path.join('/')}] "${keyword}" must be ${expected}, got ${typeName(actual)}`);
+      throw new TypeError(
+        `[/${path.join('/')}] "${keyword}" must be ${expected}, got ${typeName(actual)}`
+      );
     }
     return false;
   }
@@ -70,25 +97,59 @@ export abstract class JsonSchemaVisitor {
     return typeof v === 'boolean' || this.invalid(keyword, 'a boolean', path, v);
   }
 
-  private checkArr(v: unknown, keyword: string, path: readonly (string | number)[]): v is unknown[] {
+  private checkArr(
+    v: unknown,
+    keyword: string,
+    path: readonly (string | number)[]
+  ): v is unknown[] {
     return Array.isArray(v) || this.invalid(keyword, 'an array', path, v);
   }
 
-  private checkObj(v: unknown, keyword: string, path: readonly (string | number)[]): v is Record<string, unknown> {
-    return (typeof v === 'object' && v !== null && !Array.isArray(v)) || this.invalid(keyword, 'an object', path, v);
+  private checkObj(
+    v: unknown,
+    keyword: string,
+    path: readonly (string | number)[]
+  ): v is Record<string, unknown> {
+    return (
+      (typeof v === 'object' && v !== null && !Array.isArray(v)) ||
+      this.invalid(keyword, 'an object', path, v)
+    );
   }
 
-  private checkSchema(v: unknown, keyword: string, path: readonly (string | number)[]): v is JsonSchemaType {
-    return (typeof v === 'boolean' || (typeof v === 'object' && v !== null && !Array.isArray(v)))
-      || this.invalid(keyword, 'a schema (boolean or object)', path, v);
+  private checkSchema(
+    v: unknown,
+    keyword: string,
+    path: readonly (string | number)[]
+  ): v is JsonSchemaType {
+    return (
+      typeof v === 'boolean' ||
+      (typeof v === 'object' && v !== null && !Array.isArray(v)) ||
+      this.invalid(keyword, 'a schema (boolean or object)', path, v)
+    );
   }
 
-  private checkStrOrArr(v: unknown, keyword: string, path: readonly (string | number)[]): v is string | string[] {
-    return (typeof v === 'string' || Array.isArray(v)) || this.invalid(keyword, 'a string or array', path, v);
+  private checkStrOrArr(
+    v: unknown,
+    keyword: string,
+    path: readonly (string | number)[]
+  ): v is string | string[] {
+    return (
+      typeof v === 'string' ||
+      Array.isArray(v) ||
+      this.invalid(keyword, 'a string or array', path, v)
+    );
   }
 
-  private checkNumOrBool(v: unknown, keyword: string, path: readonly (string | number)[]): v is number | boolean {
-    return (typeof v === 'number' || typeof v === 'boolean') || this.invalid(keyword, 'a number or boolean', path, v);
+  private checkNumOrBool(
+    v: unknown,
+    keyword: string,
+    path: readonly (string | number)[]
+  ): v is number | boolean {
+    return (
+      typeof v === 'number' ||
+      typeof v === 'boolean' ||
+      this.invalid(keyword, 'a number or boolean', path, v)
+    );
   }
 
   private walk(value: unknown, context: VisitorContext): void {
@@ -111,7 +172,12 @@ export abstract class JsonSchemaVisitor {
     segments: (string | number)[],
     kind: SchemaKeywordKind = 'keyword'
   ): VisitorContext {
-    return {path: [...context.path, ...segments], depth: context.depth + 1, parentKeyword: keyword, parentKind: kind};
+    return {
+      path: [...context.path, ...segments],
+      depth: context.depth + 1,
+      parentKeyword: keyword,
+      parentKind: kind,
+    };
   }
 
   private walkKeywords(schema: Record<string, unknown>, context: VisitorContext): void {
@@ -126,8 +192,10 @@ export abstract class JsonSchemaVisitor {
     if ('$id' in schema) this.checkStr(schema.$id, '$id', context.path);
     if ('id' in schema) this.checkStr(schema.id, 'id', context.path);
     if ('$anchor' in schema) this.checkStr(schema.$anchor, '$anchor', context.path);
-    if ('$dynamicAnchor' in schema) this.checkStr(schema.$dynamicAnchor, '$dynamicAnchor', context.path);
-    if ('$recursiveAnchor' in schema) this.checkStr(schema.$recursiveAnchor, '$recursiveAnchor', context.path);
+    if ('$dynamicAnchor' in schema)
+      this.checkStr(schema.$dynamicAnchor, '$dynamicAnchor', context.path);
+    if ('$recursiveAnchor' in schema)
+      this.checkStr(schema.$recursiveAnchor, '$recursiveAnchor', context.path);
     if ('$comment' in schema) this.checkStr(schema.$comment, '$comment', context.path);
     if ('title' in schema) this.checkStr(schema.title, 'title', context.path);
     if ('description' in schema) this.checkStr(schema.description, 'description', context.path);
@@ -139,27 +207,36 @@ export abstract class JsonSchemaVisitor {
     if ('enum' in schema) this.checkArr(schema.enum, 'enum', context.path);
     if ('format' in schema) this.checkStr(schema.format, 'format', context.path);
     if ('pattern' in schema) this.checkStr(schema.pattern, 'pattern', context.path);
-    if ('contentMediaType' in schema) this.checkStr(schema.contentMediaType, 'contentMediaType', context.path);
-    if ('contentEncoding' in schema) this.checkStr(schema.contentEncoding, 'contentEncoding', context.path);
+    if ('contentMediaType' in schema)
+      this.checkStr(schema.contentMediaType, 'contentMediaType', context.path);
+    if ('contentEncoding' in schema)
+      this.checkStr(schema.contentEncoding, 'contentEncoding', context.path);
     if ('required' in schema) this.checkArr(schema.required, 'required', context.path);
-    if ('dependentRequired' in schema) this.checkObj(schema.dependentRequired, 'dependentRequired', context.path);
+    if ('dependentRequired' in schema)
+      this.checkObj(schema.dependentRequired, 'dependentRequired', context.path);
     if ('minLength' in schema) this.checkNum(schema.minLength, 'minLength', context.path);
     if ('maxLength' in schema) this.checkNum(schema.maxLength, 'maxLength', context.path);
     if ('minimum' in schema) this.checkNum(schema.minimum, 'minimum', context.path);
     if ('maximum' in schema) this.checkNum(schema.maximum, 'maximum', context.path);
-    if ('exclusiveMinimum' in schema) this.checkNumOrBool(schema.exclusiveMinimum, 'exclusiveMinimum', context.path);
-    if ('exclusiveMaximum' in schema) this.checkNumOrBool(schema.exclusiveMaximum, 'exclusiveMaximum', context.path);
+    if ('exclusiveMinimum' in schema)
+      this.checkNumOrBool(schema.exclusiveMinimum, 'exclusiveMinimum', context.path);
+    if ('exclusiveMaximum' in schema)
+      this.checkNumOrBool(schema.exclusiveMaximum, 'exclusiveMaximum', context.path);
     if ('multipleOf' in schema) this.checkNum(schema.multipleOf, 'multipleOf', context.path);
     if ('minItems' in schema) this.checkNum(schema.minItems, 'minItems', context.path);
     if ('maxItems' in schema) this.checkNum(schema.maxItems, 'maxItems', context.path);
     if ('uniqueItems' in schema) this.checkBool(schema.uniqueItems, 'uniqueItems', context.path);
     if ('minContains' in schema) this.checkNum(schema.minContains, 'minContains', context.path);
     if ('maxContains' in schema) this.checkNum(schema.maxContains, 'maxContains', context.path);
-    if ('minProperties' in schema) this.checkNum(schema.minProperties, 'minProperties', context.path);
-    if ('maxProperties' in schema) this.checkNum(schema.maxProperties, 'maxProperties', context.path);
+    if ('minProperties' in schema)
+      this.checkNum(schema.minProperties, 'minProperties', context.path);
+    if ('maxProperties' in schema)
+      this.checkNum(schema.maxProperties, 'maxProperties', context.path);
 
     if ('properties' in schema && this.checkObj(schema.properties, 'properties', context.path)) {
-      for (const [name, propSchema] of Object.entries(schema.properties as Record<string, unknown>)) {
+      for (const [name, propSchema] of Object.entries(
+        schema.properties as Record<string, unknown>
+      )) {
         if (this.checkSchema(propSchema, `properties["${name}"]`, context.path)) {
           const propCtx = this.child(context, name, ['properties', name], 'property');
           this.visitProperty(name, propSchema, propCtx);
@@ -168,8 +245,13 @@ export abstract class JsonSchemaVisitor {
       }
     }
 
-    if ('patternProperties' in schema && this.checkObj(schema.patternProperties, 'patternProperties', context.path)) {
-      for (const [pattern, patSchema] of Object.entries(schema.patternProperties as Record<string, unknown>)) {
+    if (
+      'patternProperties' in schema &&
+      this.checkObj(schema.patternProperties, 'patternProperties', context.path)
+    ) {
+      for (const [pattern, patSchema] of Object.entries(
+        schema.patternProperties as Record<string, unknown>
+      )) {
         if (this.checkSchema(patSchema, `patternProperties["${pattern}"]`, context.path)) {
           const patCtx = this.child(context, pattern, ['patternProperties', pattern], 'pattern');
           this.visitPatternProperty(pattern, patSchema, patCtx);
@@ -179,8 +261,13 @@ export abstract class JsonSchemaVisitor {
     }
 
     for (const keyword of [
-      'additionalProperties', 'unevaluatedProperties', 'propertyNames',
-      'additionalItems', 'unevaluatedItems', 'contains', 'contentSchema',
+      'additionalProperties',
+      'unevaluatedProperties',
+      'propertyNames',
+      'additionalItems',
+      'unevaluatedItems',
+      'contains',
+      'contentSchema',
     ]) {
       if (keyword in schema && this.checkSchema(schema[keyword], keyword, context.path)) {
         const keywordContext = this.child(context, keyword, [keyword]);
@@ -242,7 +329,9 @@ export abstract class JsonSchemaVisitor {
 
     for (const defsKeyword of ['$defs', 'definitions']) {
       if (defsKeyword in schema && this.checkObj(schema[defsKeyword], defsKeyword, context.path)) {
-        for (const [name, defSchema] of Object.entries(schema[defsKeyword] as Record<string, unknown>)) {
+        for (const [name, defSchema] of Object.entries(
+          schema[defsKeyword] as Record<string, unknown>
+        )) {
           if (this.checkSchema(defSchema, `${defsKeyword}["${name}"]`, context.path)) {
             const definitionContext = this.child(context, name, [defsKeyword, name], 'definition');
             this.visitDefinition(name, defSchema, definitionContext);
@@ -252,17 +341,30 @@ export abstract class JsonSchemaVisitor {
       }
     }
 
-    if ('dependentSchemas' in schema && this.checkObj(schema.dependentSchemas, 'dependentSchemas', context.path)) {
-      for (const [name, depSchema] of Object.entries(schema.dependentSchemas as Record<string, unknown>)) {
+    if (
+      'dependentSchemas' in schema &&
+      this.checkObj(schema.dependentSchemas, 'dependentSchemas', context.path)
+    ) {
+      for (const [name, depSchema] of Object.entries(
+        schema.dependentSchemas as Record<string, unknown>
+      )) {
         if (this.checkSchema(depSchema, `dependentSchemas["${name}"]`, context.path)) {
-          const dependentContext = this.child(context, name, ['dependentSchemas', name], 'definition');
+          const dependentContext = this.child(
+            context,
+            name,
+            ['dependentSchemas', name],
+            'definition'
+          );
           this.visitDefinition(name, depSchema, dependentContext);
           this.walk(depSchema, dependentContext);
         }
       }
     }
 
-    if ('dependencies' in schema && this.checkObj(schema.dependencies, 'dependencies', context.path)) {
+    if (
+      'dependencies' in schema &&
+      this.checkObj(schema.dependencies, 'dependencies', context.path)
+    ) {
       for (const [key, dep] of Object.entries(schema.dependencies as Record<string, unknown>)) {
         if (Array.isArray(dep)) continue;
         if (this.checkSchema(dep, `dependencies["${key}"]`, context.path)) {

--- a/meta_configurator/src/schema/jsonSchemaVisitor.ts
+++ b/meta_configurator/src/schema/jsonSchemaVisitor.ts
@@ -1,0 +1,276 @@
+import type {JsonSchemaObjectType, JsonSchemaType} from '@/schema/jsonSchemaType';
+
+export type SchemaKeywordKind = 'keyword' | 'property' | 'pattern' | 'definition';
+
+export interface VisitorContext {
+  readonly path: readonly (string | number)[];
+  readonly depth: number;
+  readonly parentKeyword: string | null;
+  readonly parentKind: SchemaKeywordKind | null;
+}
+
+function typeName(v: unknown): string {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  return typeof v;
+}
+
+/**
+ * Base class for traversing a JSON Schema (drafts 4–2020-12).
+ * Subclass and override whichever hooks you need. All hooks default to no-ops.
+ *
+ * @param strict When true (default), malformed keyword values throw a TypeError.
+ *               When false, invalid keywords are silently skipped.
+ *
+ * Hooks fired in traversal order per schema node:
+ * - visitSchema           – every object schema, before keyword traversal
+ * - visitBooleanSchema    – boolean schemas (true / false)
+ * - visitRef              – $ref, $dynamicRef, $recursiveRef values
+ * - visitProperty         – each named entry in `properties`
+ * - visitPatternProperty  – each entry in `patternProperties`
+ * - visitSubSchemaKeyword – single-schema keywords (items, additionalProperties, …)
+ * - visitCompositional    – allOf / anyOf / oneOf / not
+ * - visitConditional      – if / then / else
+ * - visitDefinition       – each entry in $defs, definitions, dependentSchemas,
+ *                           or schema-valued dependencies
+ */
+export abstract class JsonSchemaVisitor {
+  constructor(readonly strict = true) {}
+
+  traverse(schema: JsonSchemaType): void {
+    this.walk(schema, {path: [], depth: 0, parentKeyword: null, parentKind: null});
+  }
+
+  protected visitSchema(_schema: JsonSchemaObjectType, _ctx: VisitorContext): void {}
+  protected visitBooleanSchema(_value: boolean, _ctx: VisitorContext): void {}
+  protected visitRef(_ref: string, _ctx: VisitorContext): void {}
+  protected visitProperty(_name: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
+  protected visitPatternProperty(_pattern: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
+  protected visitSubSchemaKeyword(_keyword: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
+  protected visitCompositional(_keyword: string, _schemas: JsonSchemaType | JsonSchemaType[], _ctx: VisitorContext): void {}
+  protected visitConditional(_keyword: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
+  protected visitDefinition(_name: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
+
+  private invalid(kw: string, expected: string, path: readonly (string | number)[], actual: unknown): false {
+    if (this.strict) {
+      throw new TypeError(`[/${path.join('/')}] "${kw}" must be ${expected}, got ${typeName(actual)}`);
+    }
+    return false;
+  }
+
+  private checkStr(v: unknown, kw: string, path: readonly (string | number)[]): v is string {
+    return typeof v === 'string' || this.invalid(kw, 'a string', path, v);
+  }
+
+  private checkNum(v: unknown, kw: string, path: readonly (string | number)[]): v is number {
+    return typeof v === 'number' || this.invalid(kw, 'a number', path, v);
+  }
+
+  private checkBool(v: unknown, kw: string, path: readonly (string | number)[]): v is boolean {
+    return typeof v === 'boolean' || this.invalid(kw, 'a boolean', path, v);
+  }
+
+  private checkArr(v: unknown, kw: string, path: readonly (string | number)[]): v is unknown[] {
+    return Array.isArray(v) || this.invalid(kw, 'an array', path, v);
+  }
+
+  private checkObj(v: unknown, kw: string, path: readonly (string | number)[]): v is Record<string, unknown> {
+    return (typeof v === 'object' && v !== null && !Array.isArray(v)) || this.invalid(kw, 'an object', path, v);
+  }
+
+  private checkSchema(v: unknown, kw: string, path: readonly (string | number)[]): v is JsonSchemaType {
+    return (typeof v === 'boolean' || (typeof v === 'object' && v !== null && !Array.isArray(v)))
+      || this.invalid(kw, 'a schema (boolean or object)', path, v);
+  }
+
+  private checkStrOrArr(v: unknown, kw: string, path: readonly (string | number)[]): v is string | string[] {
+    return (typeof v === 'string' || Array.isArray(v)) || this.invalid(kw, 'a string or array', path, v);
+  }
+
+  private checkNumOrBool(v: unknown, kw: string, path: readonly (string | number)[]): v is number | boolean {
+    return (typeof v === 'number' || typeof v === 'boolean') || this.invalid(kw, 'a number or boolean', path, v);
+  }
+
+  private walk(value: unknown, ctx: VisitorContext): void {
+    if (typeof value === 'boolean') {
+      this.visitBooleanSchema(value, ctx);
+      return;
+    }
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      this.invalid('(schema)', 'a boolean or object', ctx.path, value);
+      return;
+    }
+    const schema = value as Record<string, unknown>;
+    this.visitSchema(schema as JsonSchemaObjectType, ctx);
+    this.walkKeywords(schema, ctx);
+  }
+
+  private child(
+    ctx: VisitorContext,
+    keyword: string,
+    segments: (string | number)[],
+    kind: SchemaKeywordKind = 'keyword'
+  ): VisitorContext {
+    return {path: [...ctx.path, ...segments], depth: ctx.depth + 1, parentKeyword: keyword, parentKind: kind};
+  }
+
+  private walkKeywords(schema: Record<string, unknown>, ctx: VisitorContext): void {
+    for (const kw of ['$ref', '$dynamicRef', '$recursiveRef'] as const) {
+      if (kw in schema && this.checkStr(schema[kw], kw, ctx.path)) {
+        this.visitRef(schema[kw], ctx);
+      }
+    }
+
+    // scalar keyword validation — no hooks, values accessible via visitSchema
+    if ('$schema' in schema) this.checkStr(schema.$schema, '$schema', ctx.path);
+    if ('$id' in schema) this.checkStr(schema.$id, '$id', ctx.path);
+    if ('id' in schema) this.checkStr(schema.id, 'id', ctx.path);
+    if ('$anchor' in schema) this.checkStr(schema.$anchor, '$anchor', ctx.path);
+    if ('$dynamicAnchor' in schema) this.checkStr(schema.$dynamicAnchor, '$dynamicAnchor', ctx.path);
+    if ('$recursiveAnchor' in schema) this.checkStr(schema.$recursiveAnchor, '$recursiveAnchor', ctx.path);
+    if ('$comment' in schema) this.checkStr(schema.$comment, '$comment', ctx.path);
+    if ('title' in schema) this.checkStr(schema.title, 'title', ctx.path);
+    if ('description' in schema) this.checkStr(schema.description, 'description', ctx.path);
+    if ('examples' in schema) this.checkArr(schema.examples, 'examples', ctx.path);
+    if ('deprecated' in schema) this.checkBool(schema.deprecated, 'deprecated', ctx.path);
+    if ('readOnly' in schema) this.checkBool(schema.readOnly, 'readOnly', ctx.path);
+    if ('writeOnly' in schema) this.checkBool(schema.writeOnly, 'writeOnly', ctx.path);
+    if ('type' in schema) this.checkStrOrArr(schema.type, 'type', ctx.path);
+    if ('enum' in schema) this.checkArr(schema.enum, 'enum', ctx.path);
+    if ('format' in schema) this.checkStr(schema.format, 'format', ctx.path);
+    if ('pattern' in schema) this.checkStr(schema.pattern, 'pattern', ctx.path);
+    if ('contentMediaType' in schema) this.checkStr(schema.contentMediaType, 'contentMediaType', ctx.path);
+    if ('contentEncoding' in schema) this.checkStr(schema.contentEncoding, 'contentEncoding', ctx.path);
+    if ('required' in schema) this.checkArr(schema.required, 'required', ctx.path);
+    if ('dependentRequired' in schema) this.checkObj(schema.dependentRequired, 'dependentRequired', ctx.path);
+    if ('minLength' in schema) this.checkNum(schema.minLength, 'minLength', ctx.path);
+    if ('maxLength' in schema) this.checkNum(schema.maxLength, 'maxLength', ctx.path);
+    if ('minimum' in schema) this.checkNum(schema.minimum, 'minimum', ctx.path);
+    if ('maximum' in schema) this.checkNum(schema.maximum, 'maximum', ctx.path);
+    if ('exclusiveMinimum' in schema) this.checkNumOrBool(schema.exclusiveMinimum, 'exclusiveMinimum', ctx.path);
+    if ('exclusiveMaximum' in schema) this.checkNumOrBool(schema.exclusiveMaximum, 'exclusiveMaximum', ctx.path);
+    if ('multipleOf' in schema) this.checkNum(schema.multipleOf, 'multipleOf', ctx.path);
+    if ('minItems' in schema) this.checkNum(schema.minItems, 'minItems', ctx.path);
+    if ('maxItems' in schema) this.checkNum(schema.maxItems, 'maxItems', ctx.path);
+    if ('uniqueItems' in schema) this.checkBool(schema.uniqueItems, 'uniqueItems', ctx.path);
+    if ('minContains' in schema) this.checkNum(schema.minContains, 'minContains', ctx.path);
+    if ('maxContains' in schema) this.checkNum(schema.maxContains, 'maxContains', ctx.path);
+    if ('minProperties' in schema) this.checkNum(schema.minProperties, 'minProperties', ctx.path);
+    if ('maxProperties' in schema) this.checkNum(schema.maxProperties, 'maxProperties', ctx.path);
+
+    if ('properties' in schema && this.checkObj(schema.properties, 'properties', ctx.path)) {
+      for (const [name, propSchema] of Object.entries(schema.properties as Record<string, unknown>)) {
+        if (this.checkSchema(propSchema, `properties["${name}"]`, ctx.path)) {
+          const propCtx = this.child(ctx, name, ['properties', name], 'property');
+          this.visitProperty(name, propSchema, propCtx);
+          this.walk(propSchema, propCtx);
+        }
+      }
+    }
+
+    if ('patternProperties' in schema && this.checkObj(schema.patternProperties, 'patternProperties', ctx.path)) {
+      for (const [pattern, patSchema] of Object.entries(schema.patternProperties as Record<string, unknown>)) {
+        if (this.checkSchema(patSchema, `patternProperties["${pattern}"]`, ctx.path)) {
+          const patCtx = this.child(ctx, pattern, ['patternProperties', pattern], 'pattern');
+          this.visitPatternProperty(pattern, patSchema, patCtx);
+          this.walk(patSchema, patCtx);
+        }
+      }
+    }
+
+    for (const kw of [
+      'additionalProperties', 'unevaluatedProperties', 'propertyNames',
+      'additionalItems', 'unevaluatedItems', 'contains', 'contentSchema',
+    ]) {
+      if (kw in schema && this.checkSchema(schema[kw], kw, ctx.path)) {
+        const kwCtx = this.child(ctx, kw, [kw]);
+        this.visitSubSchemaKeyword(kw, schema[kw] as JsonSchemaType, kwCtx);
+        this.walk(schema[kw], kwCtx);
+      }
+    }
+
+    if ('items' in schema) {
+      if (Array.isArray(schema.items)) {
+        schema.items.forEach((item, i) => {
+          if (this.checkSchema(item, `items[${i}]`, ctx.path)) {
+            const itemCtx = this.child(ctx, 'items', ['items', i]);
+            this.visitSubSchemaKeyword('items', item, itemCtx);
+            this.walk(item, itemCtx);
+          }
+        });
+      } else if (this.checkSchema(schema.items, 'items', ctx.path)) {
+        const itemCtx = this.child(ctx, 'items', ['items']);
+        this.visitSubSchemaKeyword('items', schema.items, itemCtx);
+        this.walk(schema.items, itemCtx);
+      }
+    }
+
+    if ('prefixItems' in schema && this.checkArr(schema.prefixItems, 'prefixItems', ctx.path)) {
+      schema.prefixItems.forEach((item, i) => {
+        if (this.checkSchema(item, `prefixItems[${i}]`, ctx.path)) {
+          const itemCtx = this.child(ctx, 'prefixItems', ['prefixItems', i]);
+          this.visitSubSchemaKeyword('prefixItems', item, itemCtx);
+          this.walk(item, itemCtx);
+        }
+      });
+    }
+
+    for (const kw of ['allOf', 'anyOf', 'oneOf']) {
+      if (kw in schema && this.checkArr(schema[kw], kw, ctx.path)) {
+        const schemas = schema[kw] as unknown[];
+        this.visitCompositional(kw, schemas as JsonSchemaType[], ctx);
+        schemas.forEach((s, i) => {
+          if (this.checkSchema(s, `${kw}[${i}]`, ctx.path)) {
+            this.walk(s, this.child(ctx, kw, [kw, i]));
+          }
+        });
+      }
+    }
+
+    if ('not' in schema && this.checkSchema(schema.not, 'not', ctx.path)) {
+      this.visitCompositional('not', schema.not, ctx);
+      this.walk(schema.not, this.child(ctx, 'not', ['not']));
+    }
+
+    for (const kw of ['if', 'then', 'else']) {
+      if (kw in schema && this.checkSchema(schema[kw], kw, ctx.path)) {
+        const kwCtx = this.child(ctx, kw, [kw]);
+        this.visitConditional(kw, schema[kw] as JsonSchemaType, kwCtx);
+        this.walk(schema[kw], kwCtx);
+      }
+    }
+
+    for (const defsKw of ['$defs', 'definitions']) {
+      if (defsKw in schema && this.checkObj(schema[defsKw], defsKw, ctx.path)) {
+        for (const [name, defSchema] of Object.entries(schema[defsKw] as Record<string, unknown>)) {
+          if (this.checkSchema(defSchema, `${defsKw}["${name}"]`, ctx.path)) {
+            const defCtx = this.child(ctx, name, [defsKw, name], 'definition');
+            this.visitDefinition(name, defSchema, defCtx);
+            this.walk(defSchema, defCtx);
+          }
+        }
+      }
+    }
+
+    if ('dependentSchemas' in schema && this.checkObj(schema.dependentSchemas, 'dependentSchemas', ctx.path)) {
+      for (const [name, depSchema] of Object.entries(schema.dependentSchemas as Record<string, unknown>)) {
+        if (this.checkSchema(depSchema, `dependentSchemas["${name}"]`, ctx.path)) {
+          const depCtx = this.child(ctx, name, ['dependentSchemas', name], 'definition');
+          this.visitDefinition(name, depSchema, depCtx);
+          this.walk(depSchema, depCtx);
+        }
+      }
+    }
+
+    if ('dependencies' in schema && this.checkObj(schema.dependencies, 'dependencies', ctx.path)) {
+      for (const [key, dep] of Object.entries(schema.dependencies as Record<string, unknown>)) {
+        if (Array.isArray(dep)) continue;
+        if (this.checkSchema(dep, `dependencies["${key}"]`, ctx.path)) {
+          const depCtx = this.child(ctx, key, ['dependencies', key], 'definition');
+          this.visitDefinition(key, dep, depCtx);
+          this.walk(dep, depCtx);
+        }
+      }
+    }
+  }
+}

--- a/meta_configurator/src/schema/jsonSchemaVisitor.ts
+++ b/meta_configurator/src/schema/jsonSchemaVisitor.ts
@@ -41,234 +41,234 @@ export abstract class JsonSchemaVisitor {
     this.walk(schema, {path: [], depth: 0, parentKeyword: null, parentKind: null});
   }
 
-  protected visitSchema(_schema: JsonSchemaObjectType, _ctx: VisitorContext): void {}
-  protected visitBooleanSchema(_value: boolean, _ctx: VisitorContext): void {}
-  protected visitRef(_ref: string, _ctx: VisitorContext): void {}
-  protected visitProperty(_name: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
-  protected visitPatternProperty(_pattern: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
-  protected visitSubSchemaKeyword(_keyword: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
-  protected visitCompositional(_keyword: string, _schemas: JsonSchemaType | JsonSchemaType[], _ctx: VisitorContext): void {}
-  protected visitConditional(_keyword: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
-  protected visitDefinition(_name: string, _schema: JsonSchemaType, _ctx: VisitorContext): void {}
+  protected visitSchema(_schema: JsonSchemaObjectType, _context: VisitorContext): void {}
+  protected visitBooleanSchema(_value: boolean, _context: VisitorContext): void {}
+  protected visitRef(_ref: string, _context: VisitorContext): void {}
+  protected visitProperty(_name: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
+  protected visitPatternProperty(_pattern: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
+  protected visitSubSchemaKeyword(_keyword: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
+  protected visitCompositional(_keyword: string, _schemas: JsonSchemaType | JsonSchemaType[], _context: VisitorContext): void {}
+  protected visitConditional(_keyword: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
+  protected visitDefinition(_name: string, _schema: JsonSchemaType, _context: VisitorContext): void {}
 
-  private invalid(kw: string, expected: string, path: readonly (string | number)[], actual: unknown): false {
+  private invalid(keyword: string, expected: string, path: readonly (string | number)[], actual: unknown): false {
     if (this.strict) {
-      throw new TypeError(`[/${path.join('/')}] "${kw}" must be ${expected}, got ${typeName(actual)}`);
+      throw new TypeError(`[/${path.join('/')}] "${keyword}" must be ${expected}, got ${typeName(actual)}`);
     }
     return false;
   }
 
-  private checkStr(v: unknown, kw: string, path: readonly (string | number)[]): v is string {
-    return typeof v === 'string' || this.invalid(kw, 'a string', path, v);
+  private checkStr(v: unknown, keyword: string, path: readonly (string | number)[]): v is string {
+    return typeof v === 'string' || this.invalid(keyword, 'a string', path, v);
   }
 
-  private checkNum(v: unknown, kw: string, path: readonly (string | number)[]): v is number {
-    return typeof v === 'number' || this.invalid(kw, 'a number', path, v);
+  private checkNum(v: unknown, keyword: string, path: readonly (string | number)[]): v is number {
+    return typeof v === 'number' || this.invalid(keyword, 'a number', path, v);
   }
 
-  private checkBool(v: unknown, kw: string, path: readonly (string | number)[]): v is boolean {
-    return typeof v === 'boolean' || this.invalid(kw, 'a boolean', path, v);
+  private checkBool(v: unknown, keyword: string, path: readonly (string | number)[]): v is boolean {
+    return typeof v === 'boolean' || this.invalid(keyword, 'a boolean', path, v);
   }
 
-  private checkArr(v: unknown, kw: string, path: readonly (string | number)[]): v is unknown[] {
-    return Array.isArray(v) || this.invalid(kw, 'an array', path, v);
+  private checkArr(v: unknown, keyword: string, path: readonly (string | number)[]): v is unknown[] {
+    return Array.isArray(v) || this.invalid(keyword, 'an array', path, v);
   }
 
-  private checkObj(v: unknown, kw: string, path: readonly (string | number)[]): v is Record<string, unknown> {
-    return (typeof v === 'object' && v !== null && !Array.isArray(v)) || this.invalid(kw, 'an object', path, v);
+  private checkObj(v: unknown, keyword: string, path: readonly (string | number)[]): v is Record<string, unknown> {
+    return (typeof v === 'object' && v !== null && !Array.isArray(v)) || this.invalid(keyword, 'an object', path, v);
   }
 
-  private checkSchema(v: unknown, kw: string, path: readonly (string | number)[]): v is JsonSchemaType {
+  private checkSchema(v: unknown, keyword: string, path: readonly (string | number)[]): v is JsonSchemaType {
     return (typeof v === 'boolean' || (typeof v === 'object' && v !== null && !Array.isArray(v)))
-      || this.invalid(kw, 'a schema (boolean or object)', path, v);
+      || this.invalid(keyword, 'a schema (boolean or object)', path, v);
   }
 
-  private checkStrOrArr(v: unknown, kw: string, path: readonly (string | number)[]): v is string | string[] {
-    return (typeof v === 'string' || Array.isArray(v)) || this.invalid(kw, 'a string or array', path, v);
+  private checkStrOrArr(v: unknown, keyword: string, path: readonly (string | number)[]): v is string | string[] {
+    return (typeof v === 'string' || Array.isArray(v)) || this.invalid(keyword, 'a string or array', path, v);
   }
 
-  private checkNumOrBool(v: unknown, kw: string, path: readonly (string | number)[]): v is number | boolean {
-    return (typeof v === 'number' || typeof v === 'boolean') || this.invalid(kw, 'a number or boolean', path, v);
+  private checkNumOrBool(v: unknown, keyword: string, path: readonly (string | number)[]): v is number | boolean {
+    return (typeof v === 'number' || typeof v === 'boolean') || this.invalid(keyword, 'a number or boolean', path, v);
   }
 
-  private walk(value: unknown, ctx: VisitorContext): void {
+  private walk(value: unknown, context: VisitorContext): void {
     if (typeof value === 'boolean') {
-      this.visitBooleanSchema(value, ctx);
+      this.visitBooleanSchema(value, context);
       return;
     }
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-      this.invalid('(schema)', 'a boolean or object', ctx.path, value);
+      this.invalid('(schema)', 'a boolean or object', context.path, value);
       return;
     }
     const schema = value as Record<string, unknown>;
-    this.visitSchema(schema as JsonSchemaObjectType, ctx);
-    this.walkKeywords(schema, ctx);
+    this.visitSchema(schema as JsonSchemaObjectType, context);
+    this.walkKeywords(schema, context);
   }
 
   private child(
-    ctx: VisitorContext,
+    context: VisitorContext,
     keyword: string,
     segments: (string | number)[],
     kind: SchemaKeywordKind = 'keyword'
   ): VisitorContext {
-    return {path: [...ctx.path, ...segments], depth: ctx.depth + 1, parentKeyword: keyword, parentKind: kind};
+    return {path: [...context.path, ...segments], depth: context.depth + 1, parentKeyword: keyword, parentKind: kind};
   }
 
-  private walkKeywords(schema: Record<string, unknown>, ctx: VisitorContext): void {
-    for (const kw of ['$ref', '$dynamicRef', '$recursiveRef'] as const) {
-      if (kw in schema && this.checkStr(schema[kw], kw, ctx.path)) {
-        this.visitRef(schema[kw], ctx);
+  private walkKeywords(schema: Record<string, unknown>, context: VisitorContext): void {
+    for (const keyword of ['$ref', '$dynamicRef', '$recursiveRef'] as const) {
+      if (keyword in schema && this.checkStr(schema[keyword], keyword, context.path)) {
+        this.visitRef(schema[keyword], context);
       }
     }
 
     // scalar keyword validation — no hooks, values accessible via visitSchema
-    if ('$schema' in schema) this.checkStr(schema.$schema, '$schema', ctx.path);
-    if ('$id' in schema) this.checkStr(schema.$id, '$id', ctx.path);
-    if ('id' in schema) this.checkStr(schema.id, 'id', ctx.path);
-    if ('$anchor' in schema) this.checkStr(schema.$anchor, '$anchor', ctx.path);
-    if ('$dynamicAnchor' in schema) this.checkStr(schema.$dynamicAnchor, '$dynamicAnchor', ctx.path);
-    if ('$recursiveAnchor' in schema) this.checkStr(schema.$recursiveAnchor, '$recursiveAnchor', ctx.path);
-    if ('$comment' in schema) this.checkStr(schema.$comment, '$comment', ctx.path);
-    if ('title' in schema) this.checkStr(schema.title, 'title', ctx.path);
-    if ('description' in schema) this.checkStr(schema.description, 'description', ctx.path);
-    if ('examples' in schema) this.checkArr(schema.examples, 'examples', ctx.path);
-    if ('deprecated' in schema) this.checkBool(schema.deprecated, 'deprecated', ctx.path);
-    if ('readOnly' in schema) this.checkBool(schema.readOnly, 'readOnly', ctx.path);
-    if ('writeOnly' in schema) this.checkBool(schema.writeOnly, 'writeOnly', ctx.path);
-    if ('type' in schema) this.checkStrOrArr(schema.type, 'type', ctx.path);
-    if ('enum' in schema) this.checkArr(schema.enum, 'enum', ctx.path);
-    if ('format' in schema) this.checkStr(schema.format, 'format', ctx.path);
-    if ('pattern' in schema) this.checkStr(schema.pattern, 'pattern', ctx.path);
-    if ('contentMediaType' in schema) this.checkStr(schema.contentMediaType, 'contentMediaType', ctx.path);
-    if ('contentEncoding' in schema) this.checkStr(schema.contentEncoding, 'contentEncoding', ctx.path);
-    if ('required' in schema) this.checkArr(schema.required, 'required', ctx.path);
-    if ('dependentRequired' in schema) this.checkObj(schema.dependentRequired, 'dependentRequired', ctx.path);
-    if ('minLength' in schema) this.checkNum(schema.minLength, 'minLength', ctx.path);
-    if ('maxLength' in schema) this.checkNum(schema.maxLength, 'maxLength', ctx.path);
-    if ('minimum' in schema) this.checkNum(schema.minimum, 'minimum', ctx.path);
-    if ('maximum' in schema) this.checkNum(schema.maximum, 'maximum', ctx.path);
-    if ('exclusiveMinimum' in schema) this.checkNumOrBool(schema.exclusiveMinimum, 'exclusiveMinimum', ctx.path);
-    if ('exclusiveMaximum' in schema) this.checkNumOrBool(schema.exclusiveMaximum, 'exclusiveMaximum', ctx.path);
-    if ('multipleOf' in schema) this.checkNum(schema.multipleOf, 'multipleOf', ctx.path);
-    if ('minItems' in schema) this.checkNum(schema.minItems, 'minItems', ctx.path);
-    if ('maxItems' in schema) this.checkNum(schema.maxItems, 'maxItems', ctx.path);
-    if ('uniqueItems' in schema) this.checkBool(schema.uniqueItems, 'uniqueItems', ctx.path);
-    if ('minContains' in schema) this.checkNum(schema.minContains, 'minContains', ctx.path);
-    if ('maxContains' in schema) this.checkNum(schema.maxContains, 'maxContains', ctx.path);
-    if ('minProperties' in schema) this.checkNum(schema.minProperties, 'minProperties', ctx.path);
-    if ('maxProperties' in schema) this.checkNum(schema.maxProperties, 'maxProperties', ctx.path);
+    if ('$schema' in schema) this.checkStr(schema.$schema, '$schema', context.path);
+    if ('$id' in schema) this.checkStr(schema.$id, '$id', context.path);
+    if ('id' in schema) this.checkStr(schema.id, 'id', context.path);
+    if ('$anchor' in schema) this.checkStr(schema.$anchor, '$anchor', context.path);
+    if ('$dynamicAnchor' in schema) this.checkStr(schema.$dynamicAnchor, '$dynamicAnchor', context.path);
+    if ('$recursiveAnchor' in schema) this.checkStr(schema.$recursiveAnchor, '$recursiveAnchor', context.path);
+    if ('$comment' in schema) this.checkStr(schema.$comment, '$comment', context.path);
+    if ('title' in schema) this.checkStr(schema.title, 'title', context.path);
+    if ('description' in schema) this.checkStr(schema.description, 'description', context.path);
+    if ('examples' in schema) this.checkArr(schema.examples, 'examples', context.path);
+    if ('deprecated' in schema) this.checkBool(schema.deprecated, 'deprecated', context.path);
+    if ('readOnly' in schema) this.checkBool(schema.readOnly, 'readOnly', context.path);
+    if ('writeOnly' in schema) this.checkBool(schema.writeOnly, 'writeOnly', context.path);
+    if ('type' in schema) this.checkStrOrArr(schema.type, 'type', context.path);
+    if ('enum' in schema) this.checkArr(schema.enum, 'enum', context.path);
+    if ('format' in schema) this.checkStr(schema.format, 'format', context.path);
+    if ('pattern' in schema) this.checkStr(schema.pattern, 'pattern', context.path);
+    if ('contentMediaType' in schema) this.checkStr(schema.contentMediaType, 'contentMediaType', context.path);
+    if ('contentEncoding' in schema) this.checkStr(schema.contentEncoding, 'contentEncoding', context.path);
+    if ('required' in schema) this.checkArr(schema.required, 'required', context.path);
+    if ('dependentRequired' in schema) this.checkObj(schema.dependentRequired, 'dependentRequired', context.path);
+    if ('minLength' in schema) this.checkNum(schema.minLength, 'minLength', context.path);
+    if ('maxLength' in schema) this.checkNum(schema.maxLength, 'maxLength', context.path);
+    if ('minimum' in schema) this.checkNum(schema.minimum, 'minimum', context.path);
+    if ('maximum' in schema) this.checkNum(schema.maximum, 'maximum', context.path);
+    if ('exclusiveMinimum' in schema) this.checkNumOrBool(schema.exclusiveMinimum, 'exclusiveMinimum', context.path);
+    if ('exclusiveMaximum' in schema) this.checkNumOrBool(schema.exclusiveMaximum, 'exclusiveMaximum', context.path);
+    if ('multipleOf' in schema) this.checkNum(schema.multipleOf, 'multipleOf', context.path);
+    if ('minItems' in schema) this.checkNum(schema.minItems, 'minItems', context.path);
+    if ('maxItems' in schema) this.checkNum(schema.maxItems, 'maxItems', context.path);
+    if ('uniqueItems' in schema) this.checkBool(schema.uniqueItems, 'uniqueItems', context.path);
+    if ('minContains' in schema) this.checkNum(schema.minContains, 'minContains', context.path);
+    if ('maxContains' in schema) this.checkNum(schema.maxContains, 'maxContains', context.path);
+    if ('minProperties' in schema) this.checkNum(schema.minProperties, 'minProperties', context.path);
+    if ('maxProperties' in schema) this.checkNum(schema.maxProperties, 'maxProperties', context.path);
 
-    if ('properties' in schema && this.checkObj(schema.properties, 'properties', ctx.path)) {
+    if ('properties' in schema && this.checkObj(schema.properties, 'properties', context.path)) {
       for (const [name, propSchema] of Object.entries(schema.properties as Record<string, unknown>)) {
-        if (this.checkSchema(propSchema, `properties["${name}"]`, ctx.path)) {
-          const propCtx = this.child(ctx, name, ['properties', name], 'property');
+        if (this.checkSchema(propSchema, `properties["${name}"]`, context.path)) {
+          const propCtx = this.child(context, name, ['properties', name], 'property');
           this.visitProperty(name, propSchema, propCtx);
           this.walk(propSchema, propCtx);
         }
       }
     }
 
-    if ('patternProperties' in schema && this.checkObj(schema.patternProperties, 'patternProperties', ctx.path)) {
+    if ('patternProperties' in schema && this.checkObj(schema.patternProperties, 'patternProperties', context.path)) {
       for (const [pattern, patSchema] of Object.entries(schema.patternProperties as Record<string, unknown>)) {
-        if (this.checkSchema(patSchema, `patternProperties["${pattern}"]`, ctx.path)) {
-          const patCtx = this.child(ctx, pattern, ['patternProperties', pattern], 'pattern');
+        if (this.checkSchema(patSchema, `patternProperties["${pattern}"]`, context.path)) {
+          const patCtx = this.child(context, pattern, ['patternProperties', pattern], 'pattern');
           this.visitPatternProperty(pattern, patSchema, patCtx);
           this.walk(patSchema, patCtx);
         }
       }
     }
 
-    for (const kw of [
+    for (const keyword of [
       'additionalProperties', 'unevaluatedProperties', 'propertyNames',
       'additionalItems', 'unevaluatedItems', 'contains', 'contentSchema',
     ]) {
-      if (kw in schema && this.checkSchema(schema[kw], kw, ctx.path)) {
-        const kwCtx = this.child(ctx, kw, [kw]);
-        this.visitSubSchemaKeyword(kw, schema[kw] as JsonSchemaType, kwCtx);
-        this.walk(schema[kw], kwCtx);
+      if (keyword in schema && this.checkSchema(schema[keyword], keyword, context.path)) {
+        const keywordContext = this.child(context, keyword, [keyword]);
+        this.visitSubSchemaKeyword(keyword, schema[keyword] as JsonSchemaType, keywordContext);
+        this.walk(schema[keyword], keywordContext);
       }
     }
 
     if ('items' in schema) {
       if (Array.isArray(schema.items)) {
         schema.items.forEach((item, i) => {
-          if (this.checkSchema(item, `items[${i}]`, ctx.path)) {
-            const itemCtx = this.child(ctx, 'items', ['items', i]);
+          if (this.checkSchema(item, `items[${i}]`, context.path)) {
+            const itemCtx = this.child(context, 'items', ['items', i]);
             this.visitSubSchemaKeyword('items', item, itemCtx);
             this.walk(item, itemCtx);
           }
         });
-      } else if (this.checkSchema(schema.items, 'items', ctx.path)) {
-        const itemCtx = this.child(ctx, 'items', ['items']);
+      } else if (this.checkSchema(schema.items, 'items', context.path)) {
+        const itemCtx = this.child(context, 'items', ['items']);
         this.visitSubSchemaKeyword('items', schema.items, itemCtx);
         this.walk(schema.items, itemCtx);
       }
     }
 
-    if ('prefixItems' in schema && this.checkArr(schema.prefixItems, 'prefixItems', ctx.path)) {
+    if ('prefixItems' in schema && this.checkArr(schema.prefixItems, 'prefixItems', context.path)) {
       schema.prefixItems.forEach((item, i) => {
-        if (this.checkSchema(item, `prefixItems[${i}]`, ctx.path)) {
-          const itemCtx = this.child(ctx, 'prefixItems', ['prefixItems', i]);
+        if (this.checkSchema(item, `prefixItems[${i}]`, context.path)) {
+          const itemCtx = this.child(context, 'prefixItems', ['prefixItems', i]);
           this.visitSubSchemaKeyword('prefixItems', item, itemCtx);
           this.walk(item, itemCtx);
         }
       });
     }
 
-    for (const kw of ['allOf', 'anyOf', 'oneOf']) {
-      if (kw in schema && this.checkArr(schema[kw], kw, ctx.path)) {
-        const schemas = schema[kw] as unknown[];
-        this.visitCompositional(kw, schemas as JsonSchemaType[], ctx);
+    for (const keyword of ['allOf', 'anyOf', 'oneOf']) {
+      if (keyword in schema && this.checkArr(schema[keyword], keyword, context.path)) {
+        const schemas = schema[keyword] as unknown[];
+        this.visitCompositional(keyword, schemas as JsonSchemaType[], context);
         schemas.forEach((s, i) => {
-          if (this.checkSchema(s, `${kw}[${i}]`, ctx.path)) {
-            this.walk(s, this.child(ctx, kw, [kw, i]));
+          if (this.checkSchema(s, `${keyword}[${i}]`, context.path)) {
+            this.walk(s, this.child(context, keyword, [keyword, i]));
           }
         });
       }
     }
 
-    if ('not' in schema && this.checkSchema(schema.not, 'not', ctx.path)) {
-      this.visitCompositional('not', schema.not, ctx);
-      this.walk(schema.not, this.child(ctx, 'not', ['not']));
+    if ('not' in schema && this.checkSchema(schema.not, 'not', context.path)) {
+      this.visitCompositional('not', schema.not, context);
+      this.walk(schema.not, this.child(context, 'not', ['not']));
     }
 
-    for (const kw of ['if', 'then', 'else']) {
-      if (kw in schema && this.checkSchema(schema[kw], kw, ctx.path)) {
-        const kwCtx = this.child(ctx, kw, [kw]);
-        this.visitConditional(kw, schema[kw] as JsonSchemaType, kwCtx);
-        this.walk(schema[kw], kwCtx);
+    for (const keyword of ['if', 'then', 'else']) {
+      if (keyword in schema && this.checkSchema(schema[keyword], keyword, context.path)) {
+        const keywordContext = this.child(context, keyword, [keyword]);
+        this.visitConditional(keyword, schema[keyword] as JsonSchemaType, keywordContext);
+        this.walk(schema[keyword], keywordContext);
       }
     }
 
-    for (const defsKw of ['$defs', 'definitions']) {
-      if (defsKw in schema && this.checkObj(schema[defsKw], defsKw, ctx.path)) {
-        for (const [name, defSchema] of Object.entries(schema[defsKw] as Record<string, unknown>)) {
-          if (this.checkSchema(defSchema, `${defsKw}["${name}"]`, ctx.path)) {
-            const defCtx = this.child(ctx, name, [defsKw, name], 'definition');
-            this.visitDefinition(name, defSchema, defCtx);
-            this.walk(defSchema, defCtx);
+    for (const defsKeyword of ['$defs', 'definitions']) {
+      if (defsKeyword in schema && this.checkObj(schema[defsKeyword], defsKeyword, context.path)) {
+        for (const [name, defSchema] of Object.entries(schema[defsKeyword] as Record<string, unknown>)) {
+          if (this.checkSchema(defSchema, `${defsKeyword}["${name}"]`, context.path)) {
+            const definitionContext = this.child(context, name, [defsKeyword, name], 'definition');
+            this.visitDefinition(name, defSchema, definitionContext);
+            this.walk(defSchema, definitionContext);
           }
         }
       }
     }
 
-    if ('dependentSchemas' in schema && this.checkObj(schema.dependentSchemas, 'dependentSchemas', ctx.path)) {
+    if ('dependentSchemas' in schema && this.checkObj(schema.dependentSchemas, 'dependentSchemas', context.path)) {
       for (const [name, depSchema] of Object.entries(schema.dependentSchemas as Record<string, unknown>)) {
-        if (this.checkSchema(depSchema, `dependentSchemas["${name}"]`, ctx.path)) {
-          const depCtx = this.child(ctx, name, ['dependentSchemas', name], 'definition');
-          this.visitDefinition(name, depSchema, depCtx);
-          this.walk(depSchema, depCtx);
+        if (this.checkSchema(depSchema, `dependentSchemas["${name}"]`, context.path)) {
+          const dependentContext = this.child(context, name, ['dependentSchemas', name], 'definition');
+          this.visitDefinition(name, depSchema, dependentContext);
+          this.walk(depSchema, dependentContext);
         }
       }
     }
 
-    if ('dependencies' in schema && this.checkObj(schema.dependencies, 'dependencies', ctx.path)) {
+    if ('dependencies' in schema && this.checkObj(schema.dependencies, 'dependencies', context.path)) {
       for (const [key, dep] of Object.entries(schema.dependencies as Record<string, unknown>)) {
         if (Array.isArray(dep)) continue;
-        if (this.checkSchema(dep, `dependencies["${key}"]`, ctx.path)) {
-          const depCtx = this.child(ctx, key, ['dependencies', key], 'definition');
-          this.visitDefinition(key, dep, depCtx);
-          this.walk(dep, depCtx);
+        if (this.checkSchema(dep, `dependencies["${key}"]`, context.path)) {
+          const dependenciesContext = this.child(context, key, ['dependencies', key], 'definition');
+          this.visitDefinition(key, dep, dependenciesContext);
+          this.walk(dep, dependenciesContext);
         }
       }
     }


### PR DESCRIPTION
**What was done:**

Introduce JsonSchemaVisitor and make use of it in code.

**Why:**

To make the JsonSchema exploration/analysis standardized and easy to perform and remove duplication of it in different other files.
