### PR TITLE
make ai endpoint settings more explicit and flexible

### DIFF
--- a/meta_configurator/src/components/panels/ai-prompts/AiPromptsPanel.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/AiPromptsPanel.vue
@@ -22,7 +22,7 @@ const props = defineProps<{
       :sessionMode="props.sessionMode">
       <p>
         Use AI to create or modify the current document. Supports any OpenAI-compatible provider —
-        configure your endpoint and model in the settings below.
+        configure your backend connection, endpoint, and model in the settings below.
       </p>
       <br />
       <ApiKey />

--- a/meta_configurator/src/components/panels/ai-prompts/ApiKey.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/ApiKey.vue
@@ -17,22 +17,31 @@ const rememberOptions = ref([
 </script>
 
 <template>
-  MetaConfigurator supports any LLM provider that implements the OpenAI API — including OpenAI,
-  Perplexity, OpenRouter, Helmholtz Blablador, Academic Cloud, and others. Switch between providers
-  by changing the endpoint and model in the settings.
+  MetaConfigurator works with any LLM provider that follows the OpenAI API format, including
+  OpenAI, Perplexity, OpenRouter, Groq, Mistral, DeepSeek, and others. You can configure the
+  connection method and model in the settings below. There are three backend options:
   <br />
   <br />
-  To use a provider directly from the browser, enter your API key below. The key is stored only in
-  your browser and sent directly to the provider — it is never sent to MetaConfigurator servers.
-  However, storing API keys in the browser carries risk: any script running on the page can
-  potentially read them, and keys may be exposed in browser history or developer tools.
+  <strong>CORS Compatible Endpoint</strong>: the browser talks directly to the AI provider. Only a
+  handful of public APIs (OpenAI and Perplexity) actually allow this. If you use this option, enter
+  your API key below. The key stays in your browser and goes straight to the provider, not to any
+  MetaConfigurator server. Keep in mind that storing API keys in the browser has some risk, since
+  any script running on the page could potentially read them.
   <br />
   <br />
-  For better security, consider using the
+  <strong>HTTPS Relay</strong>: requests go through a self-hosted
   <a href="https://github.com/MetaConfigurator/meta-configurator/tree/main/relay" target="_blank"
     >MetaConfigurator Relay</a
-  >: a lightweight self-hosted proxy that holds your provider API key server-side. When a relay is
-  configured, no key needs to be entered here.
+  >
+  over HTTPS. This is the right choice when MetaConfigurator is served over HTTPS, which is the
+  case for the stable and experimental public releases. The relay keeps the provider API key on the
+  server, so you do not need to enter anything here. Note that you cannot point this at an HTTP
+  relay from an HTTPS page; browsers will block that due to mixed-content rules.
+  <br />
+  <br />
+  <strong>HTTP Relay</strong>: the same idea as the HTTPS relay, but over plain HTTP. This only
+  makes sense when you are running MetaConfigurator locally over HTTP, for example during
+  development. It will not work when accessed from an HTTPS page for the same mixed-content reason.
   <span class="api-key-container">
     <span>Key:</span>
     <Password v-model="apiKey" placeholder="Enter your API Key" :feedback="false" />

--- a/meta_configurator/src/components/panels/ai-prompts/ApiKey.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/ApiKey.vue
@@ -17,9 +17,9 @@ const rememberOptions = ref([
 </script>
 
 <template>
-  MetaConfigurator works with any LLM provider that follows the OpenAI API format, including
-  OpenAI, Perplexity, OpenRouter, Groq, Mistral, DeepSeek, and others. You can configure the
-  connection method and model in the settings below. There are three backend options:
+  MetaConfigurator works with any LLM provider that follows the OpenAI API format, including OpenAI,
+  Perplexity, OpenRouter, Groq, Mistral, DeepSeek, and others. You can configure the connection
+  method and model in the settings below. There are three backend options:
   <br />
   <br />
   <strong>CORS Compatible Endpoint</strong>: the browser talks directly to the AI provider. Only a
@@ -33,8 +33,8 @@ const rememberOptions = ref([
   <a href="https://github.com/MetaConfigurator/meta-configurator/tree/main/relay" target="_blank"
     >MetaConfigurator Relay</a
   >
-  over HTTPS. This is the right choice when MetaConfigurator is served over HTTPS, which is the
-  case for the stable and experimental public releases. The relay keeps the provider API key on the
+  over HTTPS. This is the right choice when MetaConfigurator is served over HTTPS, which is the case
+  for the stable and experimental public releases. The relay keeps the provider API key on the
   server, so you do not need to enter anything here. Note that you cannot point this at an HTTP
   relay from an HTTPS page; browsers will block that due to mixed-content rules.
   <br />

--- a/meta_configurator/src/components/panels/ai-prompts/ApiKeyWarning.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/ApiKeyWarning.vue
@@ -11,7 +11,7 @@ import {useSettings} from '@/settings/useSettings';
 
 const apiKey: Ref<string> = getApiKeyRef();
 const settings = useSettings();
-const usingProxy = computed(() => !!settings.value.aiIntegration.endpointProxy?.trim());
+const usingProxy = computed(() => 'relay' in settings.value.aiIntegration.backend);
 const showWarning = computed(() => !usingProxy.value && apiKey.value.length <= 1);
 </script>
 

--- a/meta_configurator/src/settings/defaultSettingsData.ts
+++ b/meta_configurator/src/settings/defaultSettingsData.ts
@@ -119,10 +119,11 @@ export const SETTINGS_DATA_DEFAULT = {
   },
   aiIntegration: {
     model: 'gpt-4o-mini',
-    maxTokens: 5000,
+    max_tokens: 5000,
     temperature: 0.0,
-    endpoint: 'https://api.openai.com/v1/',
-    endpointProxy: '',
+    backend: {
+      endpoint: 'https://api.openai.com/v1/',
+    },
   },
   schemaSelectionLists: [
     {

--- a/meta_configurator/src/settings/settingsSchema.ts
+++ b/meta_configurator/src/settings/settingsSchema.ts
@@ -586,12 +586,10 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
                 relay: {
                   type: 'string',
                   title: 'Relay URL (HTTPS)',
-                  description: 'Address of your self-hosted MetaConfigurator relay. Has to start with https://.',
+                  description:
+                    'Address of your self-hosted MetaConfigurator relay. Has to start with https://.',
                   pattern: '^https://',
-                  examples: [
-                    'https://your-relay.example.com',
-                    'https://relay.myorg.com',
-                  ],
+                  examples: ['https://your-relay.example.com', 'https://relay.myorg.com'],
                 },
                 endpoint: {
                   type: 'string',
@@ -644,12 +642,10 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
                 relay: {
                   type: 'string',
                   title: 'Relay URL (HTTP)',
-                  description: 'Address of your self-hosted MetaConfigurator relay. Has to start with http://.',
+                  description:
+                    'Address of your self-hosted MetaConfigurator relay. Has to start with http://.',
                   pattern: '^http://',
-                  examples: [
-                    'http://localhost:8080',
-                    'http://localhost:18081',
-                  ],
+                  examples: ['http://localhost:8080', 'http://localhost:18081'],
                 },
                 endpoint: {
                   type: 'string',

--- a/meta_configurator/src/settings/settingsSchema.ts
+++ b/meta_configurator/src/settings/settingsSchema.ts
@@ -499,9 +499,12 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
     },
     aiIntegration: {
       type: 'object',
-      required: ['model', 'maxTokens', 'temperature', 'endpoint'],
-      additionalProperties: false,
-      description: 'Settings for AI API.',
+      required: ['model', 'temperature', 'backend'],
+      additionalProperties: {
+        title: 'Custom Model Parameter',
+        oneOf: [{type: 'string'}, {type: 'number'}, {type: 'boolean'}],
+      },
+      description: 'Settings for the AI integration.',
       properties: {
         model: {
           type: 'string',
@@ -528,12 +531,6 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
             'x-ai/grok-4-fast:free',
           ],
         },
-        maxTokens: {
-          type: 'integer',
-          description: 'The maximum number of tokens to generate.',
-          default: 5000,
-          minimum: 1,
-        },
         temperature: {
           type: 'number',
           description: 'The sampling temperature for the AI API.',
@@ -541,34 +538,158 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
           minimum: 0.0,
           maximum: 1.0,
         },
-        endpoint: {
-          type: 'string',
+        backend: {
           description:
-            'The endpoint to use for the AI API. Must follow the OpenAI API specification.',
-          default: 'https://api.openai.com/v1/',
-          examples: [
-            // OpenAI official
-            'https://api.openai.com/v1/',
-            // Perplexity (OpenAI-compatible)
-            'https://api.perplexity.ai/',
-            // OpenRouter — aggregator with 200+ models (requires relay due to CORS)
-            'https://openrouter.ai/api/v1/',
-            // Academic / institutional deployments (OpenAI-compatible)
-            'https://chat-ai.academiccloud.de/v1/',
-            'https://api.helmholtz-blablador.fz-juelich.de/v1/',
-            // Custom/self-hosted proxy
-            'https://my-llm-proxy.example.com/v1/',
+            'How MetaConfigurator connects to the AI API. ' +
+            'Use "CORS Compatible Endpoint" if your provider supports direct browser access (only a few do). ' +
+            'Use "HTTPS Relay" when MetaConfigurator is served over HTTPS, which is the case for the stable and experimental releases. ' +
+            'Use "HTTP Relay" only when running MetaConfigurator locally over HTTP. ' +
+            'Browsers will block requests that mix HTTPS and HTTP due to mixed-content restrictions.',
+          oneOf: [
+            {
+              title: 'CORS Compatible Endpoint',
+              type: 'object',
+              description:
+                'The browser connects directly to the AI API. ' +
+                'Only a handful of public APIs (OpenAI, Perplexity) allow this kind of cross-origin browser request. ' +
+                'Most providers (OpenRouter, Groq, Mistral, etc.) will reject browser requests with a CORS error, so you would need a relay for those.',
+              required: ['endpoint'],
+              additionalProperties: false,
+              properties: {
+                endpoint: {
+                  type: 'string',
+                  title: 'Endpoint URL',
+                  description:
+                    'The base URL of the AI provider. Needs to follow the OpenAI API format.',
+                  default: 'https://api.openai.com/v1/',
+                  examples: [
+                    // Known CORS-compatible endpoints
+                    'https://api.openai.com/v1/',
+                    'https://api.perplexity.ai/',
+                    // Custom self-hosted CORS proxy
+                    'https://my-cors-proxy.example.com/v1/',
+                  ],
+                },
+              },
+            },
+            {
+              title: 'HTTPS Relay',
+              type: 'object',
+              description:
+                'Requests go through a self-hosted HTTPS relay instead of directly to the provider. ' +
+                'Use this when MetaConfigurator is served over HTTPS, which is the case for the stable and experimental public releases. ' +
+                'The relay keeps the provider API key on the server, so you do not need to enter it in the browser. ' +
+                'Note that you cannot point this at an HTTP relay from an HTTPS page, as browsers will block mixed-content requests.',
+              required: ['relay', 'endpoint'],
+              additionalProperties: false,
+              properties: {
+                relay: {
+                  type: 'string',
+                  title: 'Relay URL (HTTPS)',
+                  description: 'Address of your self-hosted MetaConfigurator relay. Has to start with https://.',
+                  pattern: '^https://',
+                  examples: [
+                    'https://your-relay.example.com',
+                    'https://relay.myorg.com',
+                  ],
+                },
+                endpoint: {
+                  type: 'string',
+                  title: 'Upstream Endpoint URL',
+                  description:
+                    'The AI provider endpoint that the relay will forward requests to. Needs to follow the OpenAI API format.',
+                  default: 'https://api.openai.com/v1/',
+                  examples: [
+                    // OpenAI
+                    'https://api.openai.com/v1/',
+                    // Perplexity
+                    'https://api.perplexity.ai/',
+                    // OpenRouter — aggregator with 200+ models
+                    'https://openrouter.ai/api/v1/',
+                    // xAI (Grok)
+                    'https://api.x.ai/v1/',
+                    // Mistral AI
+                    'https://api.mistral.ai/v1/',
+                    // Groq
+                    'https://api.groq.com/openai/v1/',
+                    // DeepSeek
+                    'https://api.deepseek.com/v1/',
+                    // Together AI
+                    'https://api.together.xyz/v1/',
+                    // Fireworks AI
+                    'https://api.fireworks.ai/inference/v1/',
+                    // Cohere (OpenAI-compatible)
+                    'https://api.cohere.com/compatibility/v1/',
+                    // Google Gemini (OpenAI-compatible)
+                    'https://generativelanguage.googleapis.com/v1beta/openai/',
+                    // Academic / institutional deployments
+                    'https://chat-ai.academiccloud.de/v1/',
+                    'https://api.helmholtz-blablador.fz-juelich.de/v1/',
+                    // Custom self-hosted proxy
+                    'https://my-llm-proxy.example.com/v1/',
+                  ],
+                },
+              },
+            },
+            {
+              title: 'HTTP Relay',
+              type: 'object',
+              description:
+                'Same as the HTTPS Relay, but over plain HTTP. ' +
+                'This only makes sense when running MetaConfigurator locally over HTTP, for example during development. ' +
+                'It will not work when accessed from an HTTPS page, because browsers block mixed-content requests in that case.',
+              required: ['relay', 'endpoint'],
+              additionalProperties: false,
+              properties: {
+                relay: {
+                  type: 'string',
+                  title: 'Relay URL (HTTP)',
+                  description: 'Address of your self-hosted MetaConfigurator relay. Has to start with http://.',
+                  pattern: '^http://',
+                  examples: [
+                    'http://localhost:8080',
+                    'http://localhost:18081',
+                  ],
+                },
+                endpoint: {
+                  type: 'string',
+                  title: 'Upstream Endpoint URL',
+                  description:
+                    'The AI provider endpoint that the relay will forward requests to. Needs to follow the OpenAI API format.',
+                  default: 'https://api.openai.com/v1/',
+                  examples: [
+                    // OpenAI
+                    'https://api.openai.com/v1/',
+                    // Perplexity
+                    'https://api.perplexity.ai/',
+                    // OpenRouter — aggregator with 200+ models
+                    'https://openrouter.ai/api/v1/',
+                    // xAI (Grok)
+                    'https://api.x.ai/v1/',
+                    // Mistral AI
+                    'https://api.mistral.ai/v1/',
+                    // Groq
+                    'https://api.groq.com/openai/v1/',
+                    // DeepSeek
+                    'https://api.deepseek.com/v1/',
+                    // Together AI
+                    'https://api.together.xyz/v1/',
+                    // Fireworks AI
+                    'https://api.fireworks.ai/inference/v1/',
+                    // Cohere (OpenAI-compatible)
+                    'https://api.cohere.com/compatibility/v1/',
+                    // Google Gemini (OpenAI-compatible)
+                    'https://generativelanguage.googleapis.com/v1beta/openai/',
+                    // Academic / institutional deployments
+                    'https://chat-ai.academiccloud.de/v1/',
+                    'https://api.helmholtz-blablador.fz-juelich.de/v1/',
+                    // Custom self-hosted proxy
+                    'https://my-llm-proxy.example.com/v1/',
+                  ],
+                },
+              },
+            },
           ],
-        },
-        endpointProxy: {
-          type: 'string',
-          description:
-            'URL of a self-hosted MetaConfigurator AI Relay (e.g. http://localhost:8080). ' +
-            'When set, AI requests are forwarded to this relay instead of calling the provider endpoint directly. ' +
-            'The relay holds your provider API key server-side — you do not need to enter it in the browser. ' +
-            'Leave empty to call the provider endpoint directly.',
-          default: '',
-          examples: ['http://localhost:8080', 'https://your-relay.example.com'],
         },
       },
     },

--- a/meta_configurator/src/settings/settingsTypes.ts
+++ b/meta_configurator/src/settings/settingsTypes.ts
@@ -119,12 +119,20 @@ export interface SettingsInterfaceRdf {
   maximumNodesToVisualize: number;
 }
 
+export interface AiBackendCorsEndpoint {
+  endpoint: string;
+}
+
+export interface AiBackendRelay {
+  relay: string;
+  endpoint: string;
+}
+
 export interface SettingsInterfaceAiIntegraton {
   model: string;
-  maxTokens: number;
   temperature: number;
-  endpoint: string;
-  endpointProxy?: string;
+  backend: AiBackendCorsEndpoint | AiBackendRelay;
+  [key: string]: unknown;
 }
 
 export interface SettingsInterfaceSchemaSelectionList {

--- a/meta_configurator/src/utility/ai/aiEndpoint.ts
+++ b/meta_configurator/src/utility/ai/aiEndpoint.ts
@@ -1,35 +1,42 @@
 import axios from 'axios';
 import {useSettings} from '@/settings/useSettings';
+import {throwAiRequestError} from '@/utility/ai/aiRequestError';
 
 const BASE_URL = 'https://api.openai.com/v1';
+
+const KNOWN_SETTINGS_FIELDS = new Set(['model', 'temperature', 'backend']);
 
 export const queryOpenAI = async (
   apiKey: string,
   messages: {role: 'system' | 'user'; content: string}[],
   model: string | undefined = undefined,
-  max_tokens: number | undefined = undefined,
   temperature: number | undefined = undefined,
   endpoint: string | undefined = undefined
 ) => {
   const settings = useSettings().value.aiIntegration;
   if (!model) model = settings.model;
-  if (!max_tokens) max_tokens = settings.maxTokens;
   if (!temperature) temperature = settings.temperature;
 
-  const proxyUrl = settings.endpointProxy?.trim();
+  // Collect any extra model parameters the user added beyond the known fields
+  const extraModelParams: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(settings)) {
+    if (!KNOWN_SETTINGS_FIELDS.has(key)) {
+      extraModelParams[key] = value;
+    }
+  }
+
+  const backend = settings.backend;
   const extraHeaders: Record<string, string> = {};
 
-  if (proxyUrl) {
+  if ('relay' in backend) {
     // Route through the self-hosted relay.
-    // Pass the configured upstream endpoint so the relay can forward there directly
-    // rather than relying on a static model→endpoint mapping.
-    endpoint = proxyUrl.replace(/\/$/, '') + '/v1/chat/completions';
-    const upstreamEndpoint = (settings.endpoint ?? '').trim();
-    if (upstreamEndpoint) {
-      extraHeaders['X-Relay-Endpoint'] = upstreamEndpoint;
+    // Pass the configured upstream endpoint so the relay can forward there directly.
+    endpoint = backend.relay.replace(/\/$/, '') + '/v1/chat/completions';
+    if (backend.endpoint) {
+      extraHeaders['X-Relay-Endpoint'] = backend.endpoint.trim();
     }
   } else {
-    if (!endpoint) endpoint = settings.endpoint;
+    if (!endpoint) endpoint = backend.endpoint;
     if (!endpoint.startsWith('https://')) {
       endpoint = `${BASE_URL}/${endpoint}`;
     }
@@ -38,32 +45,28 @@ export const queryOpenAI = async (
     }
   }
 
+  const requestBody: Record<string, unknown> = {
+    model,
+    messages,
+    temperature,
+    ...extraModelParams,
+  };
+
   try {
     console.debug('Querying AI endpoint with messages: ', ...messages);
-    const response = await axios.post(
-      endpoint,
-      {
-        model,
-        messages,
-        max_tokens: max_tokens,
-        temperature: temperature,
+    const response = await axios.post(endpoint, requestBody, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        ...extraHeaders,
       },
-      {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-          ...extraHeaders,
-        },
-      }
-    );
+    });
     const resultSchema: string = response.data.choices[0].message.content;
     console.debug('Result schema from AI prompt:', resultSchema, 'based on messages:', messages);
     return resultSchema;
   } catch (error: any) {
-    console.error('Error querying OpenAI:', error);
-    const apiMessage = error?.response?.data?.error?.message;
-    if (apiMessage) throw new Error(apiMessage);
-    throw error;
+    console.error('Error querying AI endpoint:', error);
+    throwAiRequestError(error, settings.backend);
   }
 };
 

--- a/meta_configurator/src/utility/ai/aiRequestError.ts
+++ b/meta_configurator/src/utility/ai/aiRequestError.ts
@@ -1,0 +1,77 @@
+import type {AiBackendCorsEndpoint, AiBackendRelay} from '@/settings/settingsTypes';
+
+export function throwAiRequestError(
+  error: any,
+  backend: AiBackendCorsEndpoint | AiBackendRelay
+): never {
+  const status: number | undefined = error?.response?.status;
+  const machineMessage: string =
+    error?.response?.data?.error?.message ?? error?.message ?? String(error);
+
+  const raise = (userMessage: string): never => {
+    throw new Error(`${userMessage}\n\nDetails: ${machineMessage}`);
+  };
+
+  if (status === 401) {
+    raise(
+      'The API key was rejected (401 Unauthorized). Please check that the key you entered is correct and has not expired.'
+    );
+  }
+
+  if (status === 403) {
+    raise(
+      'Access was denied (403 Forbidden). Your API key may not have permission to use this model or endpoint.'
+    );
+  }
+
+  if (status === 404) {
+    raise(
+      'The endpoint or model could not be found (404). Double-check the endpoint URL and model name in your AI settings.'
+    );
+  }
+
+  if (status === 400) {
+    raise(
+      'The request was rejected by the API (400 Bad Request). A model parameter is likely wrong or not supported by the selected model. ' +
+        'For example, some models use "max_completion_tokens" instead of "max_tokens". Check your custom model parameters in the AI settings.'
+    );
+  }
+
+  if (status === 429) {
+    raise(
+      'The API rate limit has been hit (429 Too Many Requests). Please wait a moment before trying again, or check your usage quota with the provider.'
+    );
+  }
+
+  if (status !== undefined && status >= 500) {
+    raise(
+      `The AI provider returned a server error (${status}). This is likely a temporary issue on their end — try again in a moment.`
+    );
+  }
+
+  // No response received — network-level failure (CORS, mixed content, unreachable host)
+  if (!error?.response) {
+    const usingRelay = 'relay' in backend;
+    const pageIsHttps = typeof window !== 'undefined' && window.location.protocol === 'https:';
+
+    if (usingRelay && (backend as AiBackendRelay).relay.startsWith('http://') && pageIsHttps) {
+      raise(
+        'Cannot reach the relay: your relay URL uses HTTP but MetaConfigurator is served over HTTPS. ' +
+          'Browsers block mixed-content requests, so the relay must also use HTTPS in this setup.'
+      );
+    }
+
+    if (!usingRelay && pageIsHttps) {
+      raise(
+        'Could not reach the AI provider. This is most likely a CORS issue: most providers do not allow direct requests from a browser. ' +
+          'Try switching to an HTTPS Relay, or use a provider that supports CORS (OpenAI or Perplexity).'
+      );
+    }
+
+    raise(
+      'Could not connect to the AI endpoint. Check your network connection and make sure the URL in your AI settings is correct and reachable.'
+    );
+  }
+
+  raise('An unexpected error occurred while contacting the AI API.');
+}

--- a/relay/tests/settings_relay_test.json
+++ b/relay/tests/settings_relay_test.json
@@ -2,10 +2,12 @@
   "latestNewsHash": -1,
   "aiIntegration": {
     "model": "mock-model",
-    "maxTokens": 100,
+    "max_tokens": 100,
     "temperature": 0.0,
-    "endpoint": "http://localhost:9999",
-    "endpointProxy": "http://localhost:18081"
+    "backend": {
+      "relay": "http://localhost:18081",
+      "endpoint": "http://localhost:9999"
+    }
   },
   "panels": {
     "schemaEditor": [


### PR DESCRIPTION
**What was done:**

make ai endpoint settings more explicit and flexible

**Why:**

Previously, there are many situations where a user might be confused: e.g., when setting up a relay with http locally but using the https frontend, or when trying to connect with an endpoint that blocks CORS requests, etc. Now the descriptions, settings schema and error messages make the setup more explicit. Also it is now possible to use custom model parameters and not just the `max_tokens` and `temperature` fields.
