### PR TITLE
fix auto-expansion in gui view based on current selected path

### DIFF
--- a/meta_configurator/e2e/panelGuiEditor.spec.ts
+++ b/meta_configurator/e2e/panelGuiEditor.spec.ts
@@ -11,7 +11,12 @@ import {
     editStringProperty, expandOrCollapseProperty
 } from "../../tests/shared/utilsGuiEditor";
 import {SessionMode} from "../src/store/sessionMode";
-import {tpForceCurrentSelectedElement, tpForceData, tpGetData} from "../../tests/shared/utilsTestPanel";
+import {
+    tpForceCurrentSelectedElement,
+    tpForceData,
+    tpGetCurrentSelectedElement,
+    tpGetData
+} from "../../tests/shared/utilsTestPanel";
 
 test('Edit the feature testing example schema using the GUI Editor, testing basic editing and schema violations', async ({ page }) => {
     // Go to the app, pre-loading the test settings
@@ -104,6 +109,26 @@ test('Test whether selecting an element, of which the parent is collapsed in the
     await tpForceCurrentSelectedElement(page, SessionMode.SchemaEditor, elementOfInterest);
     // Expect that the elementOfInterest is now visible
     await checkPropertyExistence(page, elementOfInterest, true)
+});
+
+test('Selecting a nested field below a oneOf property expands the full visible branch', async ({ page }) => {
+    await openApp(page, 'settings_testpanel.json', null, null)
+    await selectInitialSchemaFromExamples(page, 'Autonomous Vehicle Schema');
+    await forceEditorMode(page, SessionMode.SchemaEditor)
+
+    const elementOfInterest = ['properties', 'SimulationName', 'type']
+    await checkPropertyExistence(page, elementOfInterest, false)
+
+    await tpForceCurrentSelectedElement(page, SessionMode.SchemaEditor, elementOfInterest);
+    await checkPropertyExistence(page, elementOfInterest, true)
+});
+
+test('Clicking an empty GUI field selects its path', async ({ page }) => {
+    await openApp(page, 'settings_testpanel.json', null, 'schema_medium.schema.json')
+
+    await page.getByTestId('property-data-name').click()
+
+    expect(await tpGetCurrentSelectedElement(page, SessionMode.DataEditor)).toEqual(['name'])
 });
 
 

--- a/meta_configurator/src/components/panels/gui-editor/PropertiesPanel.vue
+++ b/meta_configurator/src/components/panels/gui-editor/PropertiesPanel.vue
@@ -82,19 +82,14 @@ watch(
     // if something else is selected, unselect the last clicked element
     lastClickedElement.value = [];
 
-    const absolutePath = session.currentSelectedElement.value;
-    const pathToCutOff = session.currentPath.value;
-    const relativePath = absolutePath.slice(pathToCutOff.length);
-    if (relativePath.length > 0) {
-      const selectedSchema = props.currentSchema.subSchemaAt(relativePath);
-      const selectedNodeIsExpandable =
-        selectedSchema?.hasType('object') || selectedSchema?.hasType('array');
-      const relativePathToExpand = selectedNodeIsExpandable
-        ? relativePath
-        : relativePath.slice(0, relativePath.length - 1);
-      expandElementsByPath(relativePathToExpand);
+    const wasExpanded = expandToSelectedElement();
+    scrollToPath(session.currentSelectedElement.value);
+    if (!wasExpanded) {
+      updateTree();
+      window.setTimeout(() => {
+        scrollToPath(session.currentSelectedElement.value);
+      }, 0);
     }
-    scrollToPath(absolutePath);
   },
   {deep: true}
 );
@@ -216,6 +211,9 @@ function updateTree(initial: boolean = false) {
     if (initial) {
       expandEmptyArraysAndObjectsRecursively(currentTree.value!, props.currentPath);
     }
+    if (!arePathsEqual(lastClickedElement.value, session.currentSelectedElement.value)) {
+      expandToSelectedElement();
+    }
     loading.value = false;
   }, 0);
 }
@@ -253,12 +251,10 @@ function updateData(subPath: Path, newValue: any) {
   updateTree();
 }
 
-function clickedPropertyData(nodeData: ConfigTreeNodeData) {
+function selectPropertyPath(nodeData: ConfigTreeNodeData) {
   const path = nodeData.absolutePath;
-  if (data.dataAt(path) != undefined) {
-    lastClickedElement.value = path;
-    emit('select_path', path);
-  }
+  lastClickedElement.value = path;
+  emit('select_path', path);
 }
 
 function removeProperty(subPath: Path) {
@@ -451,9 +447,26 @@ function displayAsRegularProperty(node: any) {
   );
 }
 
-function expandElementsByPath(relativePath: Path) {
+function expandToSelectedElement(): boolean {
+  const absolutePath = session.currentSelectedElement.value;
+  const pathToCutOff = session.currentPath.value;
+  const relativePath = absolutePath.slice(pathToCutOff.length);
+  if (relativePath.length === 0) {
+    return true;
+  }
+
+  const selectedSchema = props.currentSchema.subSchemaAt(relativePath);
+  const selectedNodeIsExpandable =
+    selectedSchema?.hasType('object') || selectedSchema?.hasType('array');
+  const relativePathToExpand = selectedNodeIsExpandable
+    ? relativePath
+    : relativePath.slice(0, relativePath.length - 1);
+  return expandElementsByPath(relativePathToExpand);
+}
+
+function expandElementsByPath(relativePath: Path): boolean {
   if (relativePath.length == 0) {
-    return;
+    return true;
   }
 
   let currentNode = currentTree.value;
@@ -476,15 +489,14 @@ function expandElementsByPath(relativePath: Path) {
       }
     }
     if (childNodeToExpand === undefined) {
-      break;
+      return false;
     }
 
     expandElementChildren(childNodeToExpand);
     session.expand([childNodeToExpand.key!]);
-
-    // update current node, so the next iteration which is one level deeper will use this node to search next child
     currentNode = childNodeToExpand;
   }
+  return true;
 }
 
 function scrollToPath(absolutePath: Path) {
@@ -618,7 +630,8 @@ function isNodeHighlighted(node: GuiEditorTreeNode) {
             @update_property_value="updateData"
             @remove_property="removeProperty"
             @update_tree="updateTree"
-            @click="() => clickedPropertyData(slotProps.node.data)"
+            @click="() => selectPropertyPath(slotProps.node.data)"
+            @focusin="() => selectPropertyPath(slotProps.node.data)"
             bodyClass="w-full"
             @keydown.ctrl.i="
               (event: KeyboardEvent) => showInfoOverlayPanelInstantly(slotProps.node.data, event)


### PR DESCRIPTION
**What was done:**

- expand also children in GUI view based on selected path, down to the target
- focusing on a GUI property in GUI view now loads to selection of the corresponding schema path even if there is no instance data at this path

**Why:**

More consistent and better user experience.

