### PR TITLE
use global undo manager in AceEditor

### DIFF
--- a/meta_configurator/e2e/panelTextEditor.spec.ts
+++ b/meta_configurator/e2e/panelTextEditor.spec.ts
@@ -61,7 +61,7 @@ test('Select an example schema, enter some value and change the data format. The
 
 test('Change the internal data and check if the code editor is updated properly', async ({ page }) => {
     // Go to the app, pre-loading the schema
-    await openApp(page, 'settings_testpanel.json', null, 'schema_medium.schema.json')
+    await openApp(page, 'settings_testpanel.json', null, 'schema_medium.schema.json');
 
     // Confirm that the initial data is an empty object
     await checkCodeEditorForText(page, '{}', SessionMode.DataEditor);
@@ -75,7 +75,7 @@ test('Change the internal data and check if the code editor is updated properly'
 
 test('Change the code editor content and check if the internal data is updated properly', async ({ page }) => {
     // Go to the app, pre-loading the schema
-    await openApp(page, 'settings_testpanel.json', null, 'schema_medium.schema.json')
+    await openApp(page, 'settings_testpanel.json', null, 'schema_medium.schema.json');
 
     // Confirm that the initial data is an empty object
     await checkCodeEditorForText(page, '{}', SessionMode.DataEditor);
@@ -89,7 +89,7 @@ test('Change the code editor content and check if the internal data is updated p
 });
 
 test('Undo and redo in the code editor use the global history', async ({ page }) => {
-    await openApp(page, 'settings_testpanel.json', null, 'schema_medium.schema.json')
+    await openApp(page, 'settings_testpanel.json', null, 'schema_medium.schema.json');
 
     await forceCodeEditorText(page, '{ "name": "Alex" }', SessionMode.DataEditor);
     expect(await tpGetData(page, SessionMode.DataEditor)).toEqual({ name: 'Alex' });

--- a/meta_configurator/e2e/panelTextEditor.spec.ts
+++ b/meta_configurator/e2e/panelTextEditor.spec.ts
@@ -3,10 +3,12 @@ import {
     forceDataFormat,
     getCurrentDataFormat,
     openApp,
-    selectInitialSchemaFromExamples
+    redo,
+    selectInitialSchemaFromExamples,
+    undo
 } from "../../tests/shared/utils";
 import {SessionMode} from "../src/store/sessionMode";
-import {checkCodeEditorForText, forceCodeEditorText} from "../../tests/shared/utilsCodeEditor";
+import {checkCodeEditorForText, forceCodeEditorText, getCodeEditor} from "../../tests/shared/utilsCodeEditor";
 import {tpForceData, tpGetData} from "../../tests/shared/utilsTestPanel";
 
 
@@ -84,4 +86,22 @@ test('Change the code editor content and check if the internal data is updated p
     // Validate that the internal data is updated correctly
     const dataAfterNameEnter = await tpGetData(page, SessionMode.DataEditor);
     expect(dataAfterNameEnter).toEqual({ name: 'Alex' });
+});
+
+test('Undo and redo in the code editor use the global history', async ({ page }) => {
+    await openApp(page, 'settings_testpanel.json', null, 'schema_medium.schema.json')
+
+    await forceCodeEditorText(page, '{ "name": "Alex" }', SessionMode.DataEditor);
+    expect(await tpGetData(page, SessionMode.DataEditor)).toEqual({ name: 'Alex' });
+
+    await getCodeEditor(page, SessionMode.DataEditor).click();
+    await undo(page);
+    await page.waitForTimeout(300);
+    expect(await tpGetData(page, SessionMode.DataEditor)).toEqual({});
+    await checkCodeEditorForText(page, '{}', SessionMode.DataEditor);
+
+    await redo(page);
+    await page.waitForTimeout(300);
+    expect(await tpGetData(page, SessionMode.DataEditor)).toEqual({ name: 'Alex' });
+    await checkCodeEditorForText(page, '"name": "Alex"', SessionMode.DataEditor);
 });

--- a/meta_configurator/src/components/panels/code-editor/AceEditor.vue
+++ b/meta_configurator/src/components/panels/code-editor/AceEditor.vue
@@ -19,9 +19,14 @@ import {
 } from '@/components/panels/code-editor/setupLinkToSelectionAndData';
 import {useSettings} from '@/settings/useSettings';
 import {modeToDocumentTypeDescription, SessionMode} from '@/store/sessionMode';
-import {setupAceMode, setupAceProperties} from '@/components/panels/shared-components/aceUtils';
+import {
+  connectAceUndoManagerToGlobalUndo,
+  setupAceMode,
+  setupAceProperties,
+} from '@/components/panels/shared-components/aceUtils';
 import Message from 'primevue/message';
 import {sizeOf} from '@/utility/sizeOf';
+import {getDataForMode} from '@/data/useDataLink';
 
 const props = defineProps<{
   sessionMode: SessionMode;
@@ -42,6 +47,7 @@ onMounted(() => {
 
   setupAceMode(editor.value, settings.value);
   setupAceProperties(editor.value, settings.value);
+  connectAceUndoManagerToGlobalUndo(editor.value, getDataForMode(props.sessionMode).undoManager);
 
   setupLinkToData(editor.value, props.sessionMode);
   setupLinkToCurrentSelection(editor.value, props.sessionMode);

--- a/meta_configurator/src/components/panels/shared-components/aceUtils.ts
+++ b/meta_configurator/src/components/panels/shared-components/aceUtils.ts
@@ -2,6 +2,7 @@ import type {Editor} from 'brace';
 import {watchImmediate} from '@vueuse/core';
 import type {SettingsInterfaceRoot} from '@/settings/settingsTypes';
 import {isDarkMode} from '@/utility/darkModeUtils';
+import type {UndoManager} from '@/data/undoManager';
 
 /**
  * change the mode depending on the data format.
@@ -47,4 +48,30 @@ export function setupAceProperties(editor: Editor, settings: SettingsInterfaceRo
       }
     );
   }, 0);
+}
+
+export function connectAceUndoManagerToGlobalUndo(editor: Editor, undoManager: UndoManager) {
+  editor.getSession().setUndoManager({
+    execute() {},
+    undo() {
+      undoManager.undo();
+      return undefined as any;
+    },
+    redo() {
+      undoManager.redo();
+    },
+    reset() {
+      undoManager.clear();
+    },
+    hasUndo() {
+      return undoManager.canUndo.value;
+    },
+    hasRedo() {
+      return undoManager.canRedo.value;
+    },
+    isClean() {
+      return !undoManager.canUndo.value;
+    },
+    markClean() {},
+  } as any);
 }

--- a/tests/shared/utils.ts
+++ b/tests/shared/utils.ts
@@ -104,3 +104,18 @@ export async function selectAll(page: Page) {
     const modifier = isMac ? 'Meta' : 'Control';
     await page.keyboard.press(`${modifier}+A`);
 }
+
+export async function undo(page: Page) {
+    const isMac = os.platform() === 'darwin';
+    const modifier = isMac ? 'Meta' : 'Control';
+    await page.keyboard.press(`${modifier}+Z`);
+}
+
+export async function redo(page: Page) {
+    const isMac = os.platform() === 'darwin';
+    if (isMac) {
+        await page.keyboard.press('Meta+Shift+Z');
+    } else {
+        await page.keyboard.press('Control+Y');
+    }
+}


### PR DESCRIPTION
**What was done:**

use global undo manager in AceEditor

**Why:**

Consistency: otherwise there are two parallel conflicting undo/redo systems.