### PR TITLE
741 in the text editor panels schema violations should not be shown on parent level but only where real error is

### DIFF
--- a/meta_configurator/e2e/test-fixtures/featureTesting.schema.json
+++ b/meta_configurator/e2e/test-fixtures/featureTesting.schema.json
@@ -1,0 +1,257 @@
+{
+  "type": "object",
+  "title": "Person",
+  "description": "A person schema",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/person.schema.json",
+  "required": ["name", "firstName"],
+  "$defs": {
+    "name": {
+      "type": "string",
+      "description": "Last name"
+    },
+    "circular": {
+      "title": "Circular",
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/name",
+          "minLength": 23
+        },
+        "circular": {
+          "$ref": "#/$defs/circular"
+        }
+      }
+    },
+    "isMarried": {
+      "type": "boolean",
+      "const": true
+    }
+  },
+  "patternProperties": {
+    "^Number.*": {
+      "type": "number",
+      "description": "Any number property"
+    }
+  },
+  "if": {
+    "properties": {
+      "isMarried": {
+        "$ref": "#/$defs/isMarried"
+      }
+    },
+    "required": ["isMarried"]
+  },
+  "then": {
+    "properties": {
+      "spouse": {
+        "type": "object",
+        "description": "Spouse",
+        "properties": {
+          "name": {
+            "$ref": "#/$defs/name"
+          },
+          "firstName": {
+            "type": "string",
+            "description": "First name"
+          }
+        }
+      }
+    }
+  },
+  "dependentSchemas": {
+    "nickNames": {
+      "properties": {
+        "preferredNickName": {
+          "type": "string",
+          "description": "Preferred nick name"
+        }
+      }
+    }
+  },
+  "properties": {
+    "circular": {
+      "$ref": "#/$defs/circular"
+    },
+    "name": {
+      "$ref": "#/$defs/name"
+    },
+    "firstName": {
+      "type": "string",
+      "description": "First name",
+      "examples": ["John"],
+      "deprecated": true
+    },
+    "nickNames": {
+      "type": "array",
+      "title": "Nick names",
+      "description": "Nick names",
+      "items": {
+        "type": "string"
+      }
+    },
+    "isMarried": {
+      "type": "boolean",
+      "description": "Marital Status"
+    },
+    "telephoneNumber": {
+      "type": "integer",
+      "description": "phone number",
+      "exclusiveMinimum": 149,
+      "maximum": 159
+    },
+    "heightInMeter": {
+      "type": "number",
+      "description": "Height",
+      "exclusiveMinimum": 1.2,
+      "maximum": 2.3,
+      "multipleOf": 0.01
+    },
+    "address": {
+      "type": "object",
+      "description": "Address of the person",
+      "allOf": [
+        {
+          "properties": {
+            "street": {
+              "type": "string",
+              "description": "Street name",
+              "examples": ["Main Street"]
+            }
+          }
+        },
+        {
+          "properties": {
+            "number": {
+              "type": "number"
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "number": {
+                "multipleOf": 2
+              }
+            },
+            "required": ["number"]
+          },
+          "then": {
+            "properties": {
+              "number": {
+                "description": "Even street number"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "number": {
+                "description": "Odd street number"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "street": {
+                "const": "Main Street"
+              }
+            },
+            "required": ["street"]
+          },
+          "then": {
+            "properties": {
+              "extraInfo": {
+                "type": "string",
+                "description": "Main street extra info"
+              }
+            },
+            "required": ["extraInfo"]
+          }
+        }
+      ],
+      "dependentRequired": {
+        "city": ["zipCode"]
+      },
+      "properties": {
+        "city": {
+          "type": "string",
+          "description": "City name"
+        },
+        "zipCode": {
+          "type": "string",
+          "description": "Zip code",
+          "examples": ["12345"]
+        },
+        "country": {
+          "description": "Country name",
+          "enum": ["Germany", "India", "China", "America", "Japan", "Spain", "France"]
+        },
+        "moreInfo": {
+          "type": "object",
+          "description": "More info about the address",
+          "deprecated": true,
+          "properties": {
+            "anyThing": true,
+            "info": {
+              "type": "string",
+              "description": "Some info"
+            },
+            "neighborhood": {
+              "type": "string",
+              "description": "Neighborhood name"
+            },
+            "timeZone": {
+              "description": "Time zone",
+              "const": "UTC"
+            },
+            "booleanArray": {
+              "type": "array",
+              "description": "Boolean array",
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "numbers": {
+              "type": "array",
+              "description": "Numbers",
+              "items": {
+                "type": "number"
+              }
+            },
+            "objects": {
+              "type": "array",
+              "description": "Objects",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "age": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "partner": {
+      "title": "partner",
+      "oneOf": [
+        {
+          "type": "boolean",
+          "const": false,
+          "title": "No Partner"
+        },
+        {
+          "type": "string",
+          "title": "Partner Name"
+        }
+      ]
+    }
+  }
+}

--- a/meta_configurator/e2e/test-fixtures/personInvalid.json
+++ b/meta_configurator/e2e/test-fixtures/personInvalid.json
@@ -1,0 +1,8 @@
+{
+  "heightInMeter": 9.24,
+  "telephoneNumber": 159,
+  "isMarried": true,
+  "address": {
+    "zipCode": 4
+  }
+}

--- a/meta_configurator/e2e/textEditorAnnotations.spec.ts
+++ b/meta_configurator/e2e/textEditorAnnotations.spec.ts
@@ -1,0 +1,65 @@
+import {test, expect, type Page} from '@playwright/test';
+import {openApp} from '../../tests/shared/utils';
+import {SessionMode} from '../src/store/sessionMode';
+import {checkCodeEditorForText, getCodeEditor} from '../../tests/shared/utilsCodeEditor';
+
+/**
+ * Reads the validation annotations Ace has rendered on the editor for the given mode.
+ * Returns an array of {row (0-indexed), text} for each annotation marker.
+ */
+async function readAnnotations(
+  page: Page,
+  mode: SessionMode
+): Promise<Array<{row: number; text: string}>> {
+  return await page.evaluate(modePrefix => {
+    const editor = document.querySelector(`[id^="code-editor-${modePrefix}"]`) as HTMLElement;
+    if (!editor) return [];
+    const ace = (window as any).ace;
+    const aceEditor = ace.edit(editor.id);
+    const annotations = aceEditor.getSession().getAnnotations() as Array<{
+      row: number;
+      text: string;
+    }>;
+    return annotations.map(a => ({row: a.row, text: a.text}));
+  }, mode);
+}
+
+test('Text editor shows annotations only at the leaf-error rows, including required-at-root', async ({
+  page,
+}) => {
+  await openApp(
+    page,
+    'settings_testpanel.json',
+    'personInvalid.json',
+    'featureTesting.schema.json'
+  );
+
+  // wait for data to render
+  await checkCodeEditorForText(page, '"heightInMeter"', SessionMode.DataEditor);
+  await getCodeEditor(page, SessionMode.DataEditor).waitFor();
+
+  // give validation worker + 500ms annotation debounce time to run
+  await page.waitForTimeout(1500);
+
+  const annotations = await readAnnotations(page, SessionMode.DataEditor);
+
+  // Row map for personInvalid.json:
+  //   0: {
+  //   1:   "heightInMeter": 9.24,
+  //   2:   "telephoneNumber": 159,
+  //   3:   "isMarried": true,
+  //   4:   "address": {
+  //   5:     "zipCode": 4
+  //   6:   }
+  //   7: }
+  const rowsWithAnnotations = annotations.map(a => a.row).sort((a, b) => a - b);
+
+  // Expectation: required errors → row 0 (root opening brace), heightInMeter error → row 1,
+  // zipCode error → row 5. No annotation on the address row (4) or anywhere else.
+  expect(rowsWithAnnotations).toContain(0); // required at root
+  expect(rowsWithAnnotations).toContain(1); // heightInMeter
+  expect(rowsWithAnnotations).toContain(5); // address/zipCode
+
+  // No annotation on the address line (it would be a parent-level summary that we now filter out)
+  expect(rowsWithAnnotations).not.toContain(4);
+});

--- a/meta_configurator/src/components/panels/code-editor/__tests__/filterAnnotations.test.ts
+++ b/meta_configurator/src/components/panels/code-editor/__tests__/filterAnnotations.test.ts
@@ -1,0 +1,196 @@
+import {describe, expect, it} from 'vitest';
+import type {ErrorObject} from 'ajv';
+import {filterOutAncestorErrors} from '@/components/panels/code-editor/filterAnnotations';
+import {ValidationService} from '@/schema/validationService';
+import featureTestingSchema from '@/utility/documentation/__tests__/samples/featureTesting.schema.json';
+
+function err(
+  instancePath: string,
+  options: {keyword?: string; params?: Record<string, unknown>; message?: string} = {}
+): ErrorObject {
+  return {
+    instancePath,
+    schemaPath: '#' + instancePath,
+    keyword: options.keyword ?? 'type',
+    params: options.params ?? {},
+    message: options.message ?? 'invalid',
+  } as ErrorObject;
+}
+
+describe('filterOutAncestorErrors', () => {
+  it('drops a composite parent error when a child error exists', () => {
+    const errors = [
+      err('', {keyword: 'oneOf'}),
+      err('/foo', {keyword: 'allOf'}),
+      err('/foo/bar', {keyword: 'type'}),
+    ];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result.map(e => e.instancePath)).toEqual(['/foo/bar']);
+  });
+
+  it('keeps sibling leaf errors', () => {
+    const errors = [err('/foo/bar'), err('/foo/baz')];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result.map(e => e.instancePath)).toEqual(['/foo/bar', '/foo/baz']);
+  });
+
+  it('keeps required errors at a parent path (their target slot is empty in the data)', () => {
+    // The required error refers to a property the data does not contain, so the annotation
+    // legitimately sits at the enclosing object's path. The filter must not treat such an
+    // error as a redundant "parent summary" of unrelated sibling errors.
+    const errors = [
+      err('', {keyword: 'required', params: {missingProperty: 'name'}}),
+      err('', {keyword: 'required', params: {missingProperty: 'firstName'}}),
+      err('/heightInMeter', {keyword: 'maximum'}),
+      err('/address/zipCode', {keyword: 'type'}),
+    ];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result.map(e => ({path: e.instancePath, keyword: e.keyword}))).toEqual([
+      {path: '', keyword: 'required'},
+      {path: '', keyword: 'required'},
+      {path: '/heightInMeter', keyword: 'maximum'},
+      {path: '/address/zipCode', keyword: 'type'},
+    ]);
+  });
+
+  it('drops a required error when another error targets the same missing property', () => {
+    // contrived: a required error pointing at /foo/bar and a real validation error at /foo/bar.
+    // The required-pointer is the same effective leaf, so it should not push the real one out
+    // (errors at the same path are both kept).
+    const errors = [
+      err('/foo', {keyword: 'required', params: {missingProperty: 'bar'}}),
+      err('/foo/bar', {keyword: 'type'}),
+    ];
+
+    const result = filterOutAncestorErrors(errors);
+
+    // both share the effective leaf path /foo/bar; neither is a strict ancestor of the other
+    expect(result).toHaveLength(2);
+  });
+
+  it('drops additionalProperties parent error when there is a deeper error in the extra prop', () => {
+    const errors = [
+      err('', {keyword: 'additionalProperties', params: {additionalProperty: 'extra'}}),
+      err('/extra/inner', {keyword: 'type'}),
+    ];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result.map(e => e.instancePath)).toEqual(['/extra/inner']);
+  });
+
+  it('keeps a lone parent error when no descendant exists', () => {
+    const errors = [err('/foo', {keyword: 'required', params: {missingProperty: 'bar'}})];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result.map(e => e.instancePath)).toEqual(['/foo']);
+  });
+
+  it('keeps multiple errors at the same path', () => {
+    const errors = [err('/foo', {keyword: 'type'}), err('/foo', {keyword: 'pattern'})];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result).toHaveLength(2);
+    expect(result.every(e => e.instancePath === '/foo')).toBe(true);
+  });
+
+  it('treats path segments correctly (/foo is not an ancestor of /foobar)', () => {
+    const errors = [err('/foo'), err('/foobar')];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result.map(e => e.instancePath).sort()).toEqual(['/foo', '/foobar']);
+  });
+
+  it('collapses long ancestor chains down to the deepest descendant', () => {
+    const errors = [
+      err('', {keyword: 'oneOf'}),
+      err('/a', {keyword: 'oneOf'}),
+      err('/a/b', {keyword: 'oneOf'}),
+      err('/a/b/c', {keyword: 'oneOf'}),
+      err('/a/b/c/d', {keyword: 'type'}),
+    ];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result.map(e => e.instancePath)).toEqual(['/a/b/c/d']);
+  });
+
+  it('handles array index paths', () => {
+    const errors = [
+      err('/items', {keyword: 'allOf'}),
+      err('/items/0', {keyword: 'allOf'}),
+      err('/items/0/name', {keyword: 'type'}),
+    ];
+
+    const result = filterOutAncestorErrors(errors);
+
+    expect(result.map(e => e.instancePath)).toEqual(['/items/0/name']);
+  });
+
+  it('escapes property names containing / or ~ before treating them as path segments', () => {
+    // a required error for property "a/b" expands to effective path "/foo/a~1b", which
+    // must not match "/foo/a/b" or be matched-against incorrectly.
+    const errors = [
+      err('/foo', {keyword: 'required', params: {missingProperty: 'a/b'}}),
+      err('/foo/a/b', {keyword: 'type'}),
+    ];
+
+    const result = filterOutAncestorErrors(errors);
+
+    // The required error's effective path is /foo/a~1b, the other is /foo/a/b — they
+    // are siblings, so both survive.
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns an empty array when input is empty', () => {
+    expect(filterOutAncestorErrors([])).toEqual([]);
+  });
+
+  // Integration scenario from issue #741: validates the user's data against the
+  // feature-testing schema and confirms the filter preserves the per-property errors.
+  it('on the feature-testing schema, keeps required-at-root, heightInMeter, and zipCode errors', () => {
+    const service = new ValidationService(featureTestingSchema as any);
+    const result = service.validate({
+      heightInMeter: 9.24,
+      telephoneNumber: 159,
+      isMarried: true,
+      address: {zipCode: 4},
+    });
+
+    const filtered = filterOutAncestorErrors(result.errors);
+    const summary = filtered.map(e => ({path: e.instancePath, keyword: e.keyword}));
+
+    expect(summary).toEqual(
+      expect.arrayContaining([
+        {
+          path: '',
+          keyword: 'required',
+        },
+        {
+          path: '/heightInMeter',
+          keyword: 'maximum',
+        },
+        {
+          path: '/address/zipCode',
+          keyword: 'type',
+        },
+      ])
+    );
+
+    // both required errors (name + firstName) survive even though /heightInMeter has its own error
+    const requiredErrors = filtered.filter(e => e.keyword === 'required');
+    expect(requiredErrors).toHaveLength(2);
+    expect(
+      requiredErrors.map(e => (e.params as {missingProperty: string}).missingProperty).sort()
+    ).toEqual(['firstName', 'name']);
+  });
+});

--- a/meta_configurator/src/components/panels/code-editor/filterAnnotations.ts
+++ b/meta_configurator/src/components/panels/code-editor/filterAnnotations.ts
@@ -18,9 +18,7 @@ export function filterOutAncestorErrors(errors: ErrorObject[]): ErrorObject[] {
   const effectivePaths = errors.map(effectiveLeafPath);
   return errors.filter((_, i) => {
     const descendantPrefix = effectivePaths[i] + '/';
-    return !effectivePaths.some(
-      (other, j) => j !== i && other.startsWith(descendantPrefix)
-    );
+    return !effectivePaths.some((other, j) => j !== i && other.startsWith(descendantPrefix));
   });
 }
 

--- a/meta_configurator/src/components/panels/code-editor/filterAnnotations.ts
+++ b/meta_configurator/src/components/panels/code-editor/filterAnnotations.ts
@@ -1,0 +1,43 @@
+import type {ErrorObject} from 'ajv';
+
+/**
+ * Returns the input errors with composite parent-level errors (oneOf/anyOf/allOf/etc.)
+ * removed when a more specific child error already exists for the same subtree.
+ *
+ * Each error has an "effective leaf path": for keywords that name a specific missing or
+ * unexpected property (`required`, `additionalProperties`, `unevaluatedProperties`,
+ * `dependentRequired`, `dependencies`, `propertyNames`) it's the instancePath extended
+ * with that property name; for all other keywords it's just the instancePath.
+ *
+ * An error is dropped when its effective leaf path is a strict ancestor of another
+ * error's effective leaf path. This keeps real per-property errors (e.g. "required
+ * property 'name' is missing" at the root) while filtering out composite-keyword
+ * summaries that point at the enclosing object/array.
+ */
+export function filterOutAncestorErrors(errors: ErrorObject[]): ErrorObject[] {
+  const effectivePaths = errors.map(effectiveLeafPath);
+  return errors.filter((_, i) => {
+    const descendantPrefix = effectivePaths[i] + '/';
+    return !effectivePaths.some(
+      (other, j) => j !== i && other.startsWith(descendantPrefix)
+    );
+  });
+}
+
+function effectiveLeafPath(error: ErrorObject): string {
+  const params = (error.params ?? {}) as Record<string, unknown>;
+  const segment =
+    (typeof params.missingProperty === 'string' && params.missingProperty) ||
+    (typeof params.additionalProperty === 'string' && params.additionalProperty) ||
+    (typeof params.unevaluatedProperty === 'string' && params.unevaluatedProperty) ||
+    (typeof params.propertyName === 'string' && params.propertyName) ||
+    undefined;
+  if (segment === undefined) {
+    return error.instancePath;
+  }
+  return error.instancePath + '/' + escapeJsonPointerSegment(segment);
+}
+
+function escapeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~/g, '~0').replace(/\//g, '~1');
+}

--- a/meta_configurator/src/components/panels/code-editor/setupAnnotations.ts
+++ b/meta_configurator/src/components/panels/code-editor/setupAnnotations.ts
@@ -8,6 +8,7 @@ import {watchDebounced} from '@vueuse/core';
 import type {SessionMode} from '@/store/sessionMode';
 import {getValidationForMode} from '@/data/useDataLink';
 import {useSettings} from '@/settings/useSettings';
+import {filterOutAncestorErrors} from '@/components/panels/code-editor/filterAnnotations';
 
 /**
  * Sets up the editor to show validation errors.
@@ -23,6 +24,9 @@ export function setupAnnotationsFromValidationErrors(editor: Editor, mode: Sessi
     }
 
     let {errors} = getValidationForMode(mode).currentValidationResult.value;
+
+    // drop parent-level annotations so the text editor only highlights leaf violations
+    errors = filterOutAncestorErrors(errors);
 
     const supportsBulkPathDetermination = usePathIndexLink().determineIndexesOfPaths !== undefined;
 

--- a/meta_configurator/src/data/managedValidation.ts
+++ b/meta_configurator/src/data/managedValidation.ts
@@ -9,6 +9,7 @@ import {sizeOf} from '@/utility/sizeOf';
 // Import worker as ESM
 import ValidationWorker from '@/workers/validationWorker?worker';
 import {removeExternalReferences} from '@/schema/removeExternalReferences.ts';
+import {collapseUnionErrors} from '@/schema/collapseUnionErrors';
 
 export class ManagedValidation {
   private worker: Worker;
@@ -23,7 +24,7 @@ export class ManagedValidation {
       if (!resolver) return;
 
       if (type === 'VALIDATION_COMPLETE') {
-        resolver(new ValidationResult(result.errors || []));
+        resolver(new ValidationResult(collapseUnionErrors(result.errors || [])));
       } else if (type === 'VALIDATION_ERROR') {
         console.error('Validation worker error:', error);
         resolver(new ValidationResult([]));

--- a/meta_configurator/src/dataformats/pathIndexLinkJson.ts
+++ b/meta_configurator/src/dataformats/pathIndexLinkJson.ts
@@ -13,6 +13,22 @@ import {pathToJsonPointer} from '@/utility/pathUtils';
 import {useErrorService} from '@/utility/errorServiceInstance';
 
 /**
+ * For an object-property the CST's `range.start` points at the whitespace before the
+ * key, so using it directly would land the cursor/annotation on the previous row. For
+ * an array-element the same applies to leading whitespace. Pick the offset of the
+ * meaningful token instead: the opening quote of the key, or the value's first token.
+ */
+function startIndexOfNode(node: CstNode): number {
+  if (node.kind === 'object-property') {
+    return node.keyToken.offset;
+  }
+  if (node.kind === 'array-element') {
+    return node.valueNode.range.start;
+  }
+  return node.range.start;
+}
+
+/**
  * Implementation of PathIndexLink for JSON data.
  */
 export class PathIndexLinkJson implements PathIndexLink {
@@ -189,7 +205,7 @@ export class PathIndexLinkJson implements PathIndexLink {
   ) {
     const pathKey = pathToJsonPointer(currentPath);
     if (paths.has(pathKey) && !(pathKey in result)) {
-      result[pathKey] = currentNode.range.start;
+      result[pathKey] = startIndexOfNode(currentNode);
       if (Object.keys(result).length === paths.size) {
         return; // all paths found
       }

--- a/meta_configurator/src/schema/__tests__/collapseUnionErrors.test.ts
+++ b/meta_configurator/src/schema/__tests__/collapseUnionErrors.test.ts
@@ -1,0 +1,278 @@
+import {describe, expect, it} from 'vitest';
+import type {ErrorObject} from 'ajv';
+import {collapseUnionErrors} from '@/schema/collapseUnionErrors';
+import {ValidationService} from '@/schema/validationService';
+
+function err(overrides: Partial<ErrorObject>): ErrorObject {
+  return {
+    instancePath: '',
+    schemaPath: '#',
+    keyword: 'type',
+    params: {},
+    message: 'invalid',
+    ...overrides,
+  } as ErrorObject;
+}
+
+describe('collapseUnionErrors', () => {
+  it('collapses a oneOf cluster into a single enriched error', () => {
+    const errors = [
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf/0/maximum',
+        keyword: 'maximum',
+        message: 'must be <= 10',
+      }),
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf/1/type',
+        keyword: 'type',
+        message: 'must be string',
+      }),
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf',
+        keyword: 'oneOf',
+        message: 'must match exactly one schema in oneOf',
+      }),
+    ];
+
+    const result = collapseUnionErrors(errors);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.keyword).toBe('oneOf');
+    expect(result[0]!.instancePath).toBe('/a');
+    expect(result[0]!.message).toBe(
+      [
+        'does not match any oneOf variant:',
+        '  • variant 1: must be <= 10',
+        '  • variant 2: must be string',
+      ].join('\n')
+    );
+  });
+
+  it('collapses anyOf clusters the same way', () => {
+    const errors = [
+      err({
+        schemaPath: '#/anyOf/0/type',
+        keyword: 'type',
+        message: 'must be number',
+      }),
+      err({
+        schemaPath: '#/anyOf/1/type',
+        keyword: 'type',
+        message: 'must be boolean',
+      }),
+      err({
+        schemaPath: '#/anyOf',
+        keyword: 'anyOf',
+        message: 'must match a schema in anyOf',
+      }),
+    ];
+
+    const result = collapseUnionErrors(errors);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.message).toBe(
+      [
+        'does not match any anyOf variant:',
+        '  • variant 1: must be number',
+        '  • variant 2: must be boolean',
+      ].join('\n')
+    );
+  });
+
+  it('groups multiple sub-errors per branch into one variant line', () => {
+    const errors = [
+      err({
+        schemaPath: '#/oneOf/0/type',
+        keyword: 'type',
+        message: 'must be string',
+      }),
+      err({
+        schemaPath: '#/oneOf/0/minLength',
+        keyword: 'minLength',
+        message: 'must be at least 3 characters',
+      }),
+      err({
+        schemaPath: '#/oneOf',
+        keyword: 'oneOf',
+        message: 'must match exactly one schema in oneOf',
+      }),
+    ];
+
+    const result = collapseUnionErrors(errors);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.message).toBe(
+      [
+        'does not match any oneOf variant:',
+        '  • variant 1: must be string; must be at least 3 characters',
+      ].join('\n')
+    );
+  });
+
+  it('handles multiple sibling oneOf clusters independently', () => {
+    const errors = [
+      // cluster at /a
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf/0/type',
+        keyword: 'type',
+        message: 'must be string',
+      }),
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf',
+        keyword: 'oneOf',
+      }),
+      // cluster at /b
+      err({
+        instancePath: '/b',
+        schemaPath: '#/properties/b/oneOf/0/type',
+        keyword: 'type',
+        message: 'must be number',
+      }),
+      err({
+        instancePath: '/b',
+        schemaPath: '#/properties/b/oneOf',
+        keyword: 'oneOf',
+      }),
+    ];
+
+    const result = collapseUnionErrors(errors);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.instancePath).toBe('/a');
+    expect(result[1]!.instancePath).toBe('/b');
+    expect(result[0]!.message).toContain('must be string');
+    expect(result[1]!.message).toContain('must be number');
+  });
+
+  it('preserves the summary unchanged if it has no matching branch sub-errors', () => {
+    const errors = [
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf',
+        keyword: 'oneOf',
+        message: 'must match exactly one schema in oneOf',
+      }),
+    ];
+
+    const result = collapseUnionErrors(errors);
+
+    expect(result).toEqual(errors);
+  });
+
+  it('passes unrelated errors through untouched', () => {
+    const errors = [
+      err({instancePath: '/x', keyword: 'type', schemaPath: '#/properties/x/type'}),
+      err({instancePath: '/y', keyword: 'maximum', schemaPath: '#/properties/y/maximum'}),
+    ];
+
+    const result = collapseUnionErrors(errors);
+
+    expect(result).toEqual(errors);
+  });
+
+  it('is idempotent', () => {
+    const errors = [
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf/0/maximum',
+        keyword: 'maximum',
+      }),
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf/1/type',
+        keyword: 'type',
+      }),
+      err({
+        instancePath: '/a',
+        schemaPath: '#/properties/a/oneOf',
+        keyword: 'oneOf',
+      }),
+    ];
+
+    const once = collapseUnionErrors(errors);
+    const twice = collapseUnionErrors(once);
+
+    expect(twice).toEqual(once);
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(collapseUnionErrors([])).toEqual([]);
+  });
+
+  it('collapses nested unions (oneOf in oneOf in anyOf) into a single tree-shaped error', () => {
+    const service = new ValidationService({
+      type: 'object',
+      properties: {
+        a: {
+          anyOf: [
+            {
+              oneOf: [
+                {
+                  oneOf: [
+                    {type: 'integer', maximum: 5},
+                    {type: 'string', minLength: 3},
+                  ],
+                },
+                {type: 'boolean'},
+              ],
+            },
+            {type: 'null'},
+          ],
+        },
+      },
+    } as any);
+
+    const raw = service.validate({a: 100}).errors;
+    const collapsed = collapseUnionErrors(raw);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]!.instancePath).toBe('/a');
+    expect(collapsed[0]!.keyword).toBe('anyOf');
+    expect(collapsed[0]!.message).toBe(
+      [
+        'does not match any anyOf variant:',
+        '  • variant 1: does not match any oneOf variant:',
+        '    • variant 1.1: does not match any oneOf variant:',
+        '      • variant 1.1.1: must be <= 5',
+        '      • variant 1.1.2: must be string',
+        '    • variant 1.2: must be boolean',
+        '  • variant 2: must be null',
+      ].join('\n')
+    );
+  });
+
+  // integration: run real AJV against the schema/data from the issue discussion
+  it("produces a single annotation for the user's oneOf example", () => {
+    const service = new ValidationService({
+      type: 'object',
+      properties: {
+        a: {
+          oneOf: [
+            {type: 'integer', maximum: 10},
+            {type: 'string', maxLength: 4},
+          ],
+        },
+      },
+    } as any);
+
+    // ValidationService doesn't currently apply the collapse itself — call it explicitly
+    const raw = service.validate({a: 345}).errors;
+    const collapsed = collapseUnionErrors(raw);
+
+    expect(collapsed).toHaveLength(1);
+    expect(collapsed[0]!.instancePath).toBe('/a');
+    expect(collapsed[0]!.keyword).toBe('oneOf');
+    expect(collapsed[0]!.message).toBe(
+      [
+        'does not match any oneOf variant:',
+        '  • variant 1: must be <= 10',
+        '  • variant 2: must be string',
+      ].join('\n')
+    );
+  });
+});

--- a/meta_configurator/src/schema/collapseUnionErrors.ts
+++ b/meta_configurator/src/schema/collapseUnionErrors.ts
@@ -1,0 +1,184 @@
+import type {ErrorObject} from 'ajv';
+
+const UNION_KEYWORDS = new Set(['oneOf', 'anyOf']);
+
+const isUnionSummary = (e: ErrorObject): boolean => UNION_KEYWORDS.has(e.keyword);
+
+type BranchItem = {kind: 'leaf'; message: string} | {kind: 'innerSummary'; index: number};
+
+/**
+ * True when `errorPath` sits inside another summary that is itself nested strictly
+ * inside `outerSummaryPath`. Used to skip errors that belong to a deeper summary and
+ * will be picked up when we recurse into that deeper summary instead.
+ */
+function isUnderDeeperSummary(
+  errorPath: string,
+  outerSummaryPath: string,
+  allSummaryPaths: readonly string[]
+): boolean {
+  return allSummaryPaths.some(
+    p =>
+      p !== outerSummaryPath &&
+      p.startsWith(outerSummaryPath + '/') &&
+      errorPath.startsWith(p + '/')
+  );
+}
+
+/**
+ * Groups the immediate sub-errors of one summary by branch index. Each sub-error is
+ * tagged as either a leaf (a regular schema violation) or an innerSummary (a nested
+ * oneOf/anyOf that gets recursed into during formatting).
+ */
+function directBranchesOf(
+  summary: ErrorObject,
+  errors: readonly ErrorObject[],
+  allSummaryPaths: readonly string[]
+): Map<number, BranchItem[]> {
+  const branchPrefix = summary.schemaPath + '/';
+  const branches = new Map<number, BranchItem[]>();
+
+  errors.forEach((e, i) => {
+    if (e === summary) return;
+    if (!e.schemaPath.startsWith(branchPrefix)) return;
+    if (isUnderDeeperSummary(e.schemaPath, summary.schemaPath, allSummaryPaths)) return;
+
+    const branchSeg = e.schemaPath.slice(branchPrefix.length).split('/', 1)[0];
+    const branchIdx = Number.parseInt(branchSeg, 10);
+    if (!Number.isFinite(branchIdx) || branchIdx < 0) return;
+
+    const item: BranchItem = isUnionSummary(e)
+      ? {kind: 'innerSummary', index: i}
+      : {kind: 'leaf', message: e.message ?? 'invalid'};
+    appendTo(branches, branchIdx, item);
+  });
+
+  return branches;
+}
+
+function appendTo<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  let bucket = map.get(key);
+  if (!bucket) {
+    bucket = [];
+    map.set(key, bucket);
+  }
+  bucket.push(value);
+}
+
+const INDENT_STEP = '  ';
+const BULLET_PREFIX = '  • '; // one level of indent followed by the bullet character
+
+/** Indents every line of the given multi-line text by one level. */
+function indent(text: string): string {
+  return text
+    .split('\n')
+    .map(line => INDENT_STEP + line)
+    .join('\n');
+}
+
+/**
+ * Recursively formats one summary as a multi-line tree of bullet points. Each branch
+ * becomes one bullet labelled "variant <hierarchicalNumber>: ..."; a branch that
+ * contains an inner summary embeds the inner summary's header on the same bullet line
+ * and indents its own bullets one level deeper. The originating oneOf/anyOf keyword
+ * is preserved at every level.
+ */
+function formatSummary(
+  summaryIdx: number,
+  numberingPrefix: string,
+  errors: readonly ErrorObject[],
+  allSummaryPaths: readonly string[]
+): string {
+  const summary = errors[summaryIdx]!;
+  const branches = directBranchesOf(summary, errors, allSummaryPaths);
+
+  const bulletLines: string[] = [];
+  for (const [branchIdx, items] of [...branches.entries()].sort(([a], [b]) => a - b)) {
+    const variantLabel = `variant ${numberingPrefix}${branchIdx + 1}`;
+    bulletLines.push(...formatBranchBullets(variantLabel, items, errors, allSummaryPaths));
+  }
+
+  return [`does not match any ${summary.keyword} variant:`, ...bulletLines].join('\n');
+}
+
+/**
+ * Returns the bullet lines that represent one branch of a summary. A branch may
+ * contribute a single leaf bullet (joining any multi-keyword failures with "; ") and/or
+ * one bullet per inner summary it contains.
+ */
+function formatBranchBullets(
+  variantLabel: string,
+  items: readonly BranchItem[],
+  errors: readonly ErrorObject[],
+  allSummaryPaths: readonly string[]
+): string[] {
+  const bullets: string[] = [];
+  const leafMessages = items
+    .filter((it): it is Extract<BranchItem, {kind: 'leaf'}> => it.kind === 'leaf')
+    .map(it => it.message);
+  if (leafMessages.length > 0) {
+    bullets.push(`${BULLET_PREFIX}${variantLabel}: ${leafMessages.join('; ')}`);
+  }
+  for (const item of items) {
+    if (item.kind !== 'innerSummary') continue;
+    const innerNumbering = variantLabel.replace(/^variant /, '') + '.';
+    const innerText = formatSummary(item.index, innerNumbering, errors, allSummaryPaths);
+    const [innerHeader, ...innerBody] = innerText.split('\n');
+    bullets.push(`${BULLET_PREFIX}${variantLabel}: ${innerHeader}`);
+    for (const line of innerBody) bullets.push(indent(line));
+  }
+  return bullets;
+}
+
+/**
+ * The subset of summaries that are not nested inside any other union summary.
+ * Each top-level summary becomes one annotation; everything underneath is absorbed.
+ */
+function topLevelSummaryIndices(
+  summaryIndices: readonly number[],
+  errors: readonly ErrorObject[]
+): number[] {
+  const allPaths = summaryIndices.map(i => errors[i]!.schemaPath);
+  return summaryIndices.filter(i => {
+    const path = errors[i]!.schemaPath;
+    return !allPaths.some(p => p !== path && path.startsWith(p + '/'));
+  });
+}
+
+/**
+ * Collapses each oneOf/anyOf cluster of AJV errors into a single summary error whose
+ * message walks the variant tree with hierarchical numbering ("variant 1.2.1") and
+ * parentheses delimiting each nested union, with the originating oneOf/anyOf keyword
+ * preserved at every level. The function is idempotent.
+ */
+export function collapseUnionErrors(errors: ErrorObject[]): ErrorObject[] {
+  const summaryIndices: number[] = [];
+  errors.forEach((e, i) => {
+    if (isUnionSummary(e)) summaryIndices.push(i);
+  });
+  if (summaryIndices.length === 0) return errors;
+
+  const allSummaryPaths = summaryIndices.map(i => errors[i]!.schemaPath);
+  const replacements = new Map<number, ErrorObject>();
+
+  for (const topIdx of topLevelSummaryIndices(summaryIndices, errors)) {
+    const summary = errors[topIdx]!;
+    const branches = directBranchesOf(summary, errors, allSummaryPaths);
+    if (branches.size === 0) continue; // nothing to enrich; leave the summary alone
+    replacements.set(topIdx, {
+      ...summary,
+      message: formatSummary(topIdx, '', errors, allSummaryPaths),
+    });
+  }
+
+  if (replacements.size === 0) return errors;
+
+  // anything strictly inside a replaced top-level summary is absorbed and dropped
+  const replacedPathPrefixes = [...replacements.keys()].map(i => errors[i]!.schemaPath + '/');
+  const dropped = new Set<number>();
+  errors.forEach((e, i) => {
+    if (replacements.has(i)) return;
+    if (replacedPathPrefixes.some(p => e.schemaPath.startsWith(p))) dropped.add(i);
+  });
+
+  return errors.map((e, i) => replacements.get(i) ?? e).filter((_, i) => !dropped.has(i));
+}


### PR DESCRIPTION
**What was done:**

- [Improve error annotations display](https://github.com/MetaConfigurator/meta-configurator/commit/aa984236651a4d9f3d23d45f4af7f94c6cbe9014)
- [collapse union validation errors and filter out root level annotations](https://github.com/MetaConfigurator/meta-configurator/commit/9bc84e61f0c1fa67de252559df8da7a57358cd26)

**Why:**

Better user experience.