### PR TITLE
988 fix schema migration bug

### DIFF
--- a/meta_configurator/src/settings/__tests__/settingsSchemaConsistency.test.ts
+++ b/meta_configurator/src/settings/__tests__/settingsSchemaConsistency.test.ts
@@ -1,0 +1,145 @@
+import {describe, expect, it} from 'vitest';
+import {SETTINGS_DATA_DEFAULT} from '@/settings/defaultSettingsData';
+import {SETTINGS_SCHEMA} from '@/settings/settingsSchema';
+import {resolveInternalReferenceSchema} from '@/schema/schemaReferenceUtils';
+import {mergeAllOfs} from '@/schema/mergeAllOfs';
+import {nonBooleanSchema} from '@/schema/schemaTypeUtils';
+
+function resolveSchema(schema: any, rootSchema: any): any {
+  const referencedSchema = schema?.$ref
+    ? resolveInternalReferenceSchema(schema.$ref, rootSchema)
+    : schema;
+  const mergedSchema = referencedSchema?.allOf ? mergeAllOfs(referencedSchema) : referencedSchema;
+  return nonBooleanSchema(mergedSchema);
+}
+
+function findDefaultKeysMissingRequired(
+  schema: any,
+  defaultValue: any,
+  rootSchema: any,
+  path: string[] = []
+): string[] {
+  const resolvedSchema = resolveSchema(schema, rootSchema);
+  const missing: string[] = [];
+
+  if (resolvedSchema?.type === 'array' && Array.isArray(defaultValue)) {
+    for (const item of defaultValue) {
+      missing.push(
+        ...findDefaultKeysMissingRequired(resolvedSchema.items, item, rootSchema, [...path, '[]'])
+      );
+    }
+    return missing;
+  }
+
+  if (
+    resolvedSchema?.type !== 'object' ||
+    defaultValue === null ||
+    typeof defaultValue !== 'object' ||
+    Array.isArray(defaultValue)
+  ) {
+    return missing;
+  }
+
+  const schemaProperties = resolvedSchema.properties ?? {};
+  const required = new Set(resolvedSchema.required ?? []);
+
+  if (resolvedSchema.additionalProperties === false) {
+    for (const key of Object.keys(defaultValue)) {
+      if (schemaProperties[key] !== undefined && !required.has(key)) {
+        missing.push([...path, key].join('.'));
+      }
+    }
+  }
+
+  for (const [key, propertySchema] of Object.entries(schemaProperties)) {
+    if (key in defaultValue) {
+      missing.push(
+        ...findDefaultKeysMissingRequired(propertySchema, defaultValue[key], rootSchema, [
+          ...path,
+          key,
+        ])
+      );
+    }
+  }
+
+  return [...new Set(missing)];
+}
+
+describe('settings schema consistency', () => {
+  it('marks all defaulted fields in closed settings objects as required for migration', () => {
+    expect(
+      findDefaultKeysMissingRequired(SETTINGS_SCHEMA, SETTINGS_DATA_DEFAULT, SETTINGS_SCHEMA)
+    ).toEqual([]);
+  });
+
+  it('finds defaulted properties missing from required in closed objects', () => {
+    const schema = {
+      type: 'object',
+      additionalProperties: false,
+      required: ['present'],
+      properties: {
+        present: {type: 'string'},
+        missing: {type: 'string'},
+      },
+    };
+    const defaults = {
+      present: 'ok',
+      missing: 'should be required',
+    };
+
+    expect(findDefaultKeysMissingRequired(schema, defaults, schema)).toEqual(['missing']);
+  });
+
+  it('does not require defaulted properties in open objects', () => {
+    const schema = {
+      type: 'object',
+      additionalProperties: true,
+      required: ['present'],
+      properties: {
+        present: {type: 'string'},
+        optional: {type: 'string'},
+      },
+    };
+    const defaults = {
+      present: 'ok',
+      optional: 'allowed to be optional',
+    };
+
+    expect(findDefaultKeysMissingRequired(schema, defaults, schema)).toEqual([]);
+  });
+
+  it('finds missing required entries in referenced array item schemas', () => {
+    const schema = {
+      type: 'object',
+      additionalProperties: false,
+      required: ['items'],
+      properties: {
+        items: {
+          type: 'array',
+          items: {$ref: '#/$defs/item'},
+        },
+      },
+      $defs: {
+        item: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['label'],
+          properties: {
+            label: {type: 'string'},
+            size: {type: 'number'},
+          },
+        },
+      },
+    };
+    const defaults = {
+      items: [
+        {
+          label: 'one',
+          size: 50,
+        },
+      ],
+    };
+
+    expect(findDefaultKeysMissingRequired(schema, defaults, schema)).toEqual(['items.[].size']);
+  });
+});

--- a/meta_configurator/src/settings/settingsSchema.ts
+++ b/meta_configurator/src/settings/settingsSchema.ts
@@ -6,8 +6,12 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
   description: 'MetaConfigurator settings',
   type: 'object',
   required: [
+    'settingsVersion',
+    'latestNewsHash',
     'dataFormat',
     'toolbarTitle',
+    'hideSchemaEditor',
+    'hideSettings',
     'performance',
     'textEditor',
     'guiEditor',
@@ -19,6 +23,7 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
     'backend',
     'rdf',
     'aiIntegration',
+    'schemaSelectionLists',
   ],
   additionalProperties: false,
   properties: {
@@ -357,7 +362,14 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
     },
     metaSchema: {
       type: 'object',
-      required: ['allowBooleanSchema', 'allowMultipleTypes', 'objectTypesComfort'],
+      required: [
+        'allowBooleanSchema',
+        'allowMultipleTypes',
+        'objectTypesComfort',
+        'markMoreFieldsAsAdvanced',
+        'showAdditionalPropertiesButton',
+        'showJsonLdFields',
+      ],
       additionalProperties: false,
       description:
         'Meta Schema related settings belong here. They affect the functionality of the schema editor. By making the meta schema more expressive (e.g., by allowing multiple data types for a property), the schema editor will be more powerful but also more complicated.',
@@ -811,7 +823,7 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
       description: 'Which panels to show in the editor and their order.',
       items: {
         type: 'object',
-        required: ['panelType', 'mode'],
+        required: ['panelType', 'mode', 'size'],
         additionalProperties: false,
         title: 'Panel',
         description: 'Panel type and tool mode.',


### PR DESCRIPTION
**What was done:**

Marked more properties in the settings schema as required and added regression test to avoid inconsistencies in the future.

**Why:**

When new settings get added to MetaConfigurator, older users of MC will not yet have these new setting properties. We do not want to overwrite the complete settings of those users but just extend the missing ones.
The current migration logic only copies missing properties from the default settings to the user settings if those missing properties are marked as required as per schema. Some essential properties have not been marked as required and hence were not migrated which resulted in missing settings properties and error messages in the tool.
By marking them as required, the migration process should now properly migrate them.