### PR TITLE
remove XML as dataformat and instead introduce XML import and XML export

### DIFF
--- a/meta_configurator/e2e/panelTextEditor.spec.ts
+++ b/meta_configurator/e2e/panelTextEditor.spec.ts
@@ -36,11 +36,6 @@ test('Select an example schema, enter some value and change the data format. The
     expect(await getCurrentDataFormat(page)).toBe('yaml');
     await checkCodeEditorForText(page, 'SimulationName: TestName', SessionMode.DataEditor);
 
-    // Change the data format to XML and check that the code editor shows the correct XML data
-    await forceDataFormat(page, 'xml');
-    expect(await getCurrentDataFormat(page)).toBe('xml');
-    await checkCodeEditorForText(page, '<SimulationName>TestName</SimulationName>', SessionMode.DataEditor);
-
     // Change the data format to JSON
     await forceDataFormat(page, 'json');
     expect(await getCurrentDataFormat(page)).toBe('json');

--- a/meta_configurator/src/components/panels/code-editor/AceEditor.vue
+++ b/meta_configurator/src/components/panels/code-editor/AceEditor.vue
@@ -76,13 +76,7 @@ watch(
 );
 
 function isEditorReadOnly(): boolean {
-  const dataFormat = settings.value.dataFormat;
-  const mode = props.sessionMode;
-
-  // if the editor is in schema/settings mode, XML is in read only because it will mess up the structure otherwise
-  return (
-    (mode === SessionMode.SchemaEditor || mode === SessionMode.Settings) && dataFormat === 'xml'
-  );
+  return false;
 }
 
 const featuresDisabledForPerformance = computed(() => {

--- a/meta_configurator/src/components/toolbar/Toolbar.vue
+++ b/meta_configurator/src/components/toolbar/Toolbar.vue
@@ -9,6 +9,8 @@ import AboutDialog from '@/components/toolbar/dialogs/AboutDialog.vue';
 import DataMappingDialog from '@/components/toolbar/dialogs/data-mapping/DataMappingDialog.vue';
 import ImportCsvDialog from '@/components/toolbar/dialogs/csvimport/ImportCsvDialog.vue';
 import ImportTurtleDialog from '@/components/toolbar/dialogs/turtle-import/ImportTurtleDialog.vue';
+import ImportXmlDialog from '@/components/toolbar/dialogs/xml-import/ImportXmlDialog.vue';
+import XmlExportDialog from '@/components/toolbar/dialogs/xml-export/XmlExportDialog.vue';
 import SaveSnapshotDialog from '@/components/toolbar/dialogs/snapshot/SaveSnapshotDialog.vue';
 import CodeGenerationDialog from '@/components/toolbar/dialogs/code-generation/CodeGenerationDialog.vue';
 import FetchedSchemasSelectionDialog from '@/components/toolbar/dialogs/FetchedSchemasSelectionDialog.vue';
@@ -107,6 +109,14 @@ function showTurtleImportDialog() {
   turtleImportDialog.value?.show();
 }
 
+function showXmlImportDialog() {
+  xmlImportDialog.value?.show();
+}
+
+function showXmlExportDialog() {
+  xmlExportDialog.value?.show();
+}
+
 function showSnapshotDialog() {
   snapshotDialog.value?.show();
 }
@@ -158,6 +168,8 @@ const urlInputDialog = ref();
 const dataMappingDialog = ref();
 const rmlMappingDialog = ref();
 const turtleImportDialog = ref();
+const xmlImportDialog = ref();
+const xmlExportDialog = ref();
 
 defineExpose({
   showInitialSchemaDialog: showInitialDialog,
@@ -191,6 +203,10 @@ defineExpose({
 
   <ImportTurtleDialog ref="turtleImportDialog" />
 
+  <ImportXmlDialog ref="xmlImportDialog" />
+
+  <XmlExportDialog ref="xmlExportDialog" />
+
   <SaveSnapshotDialog ref="snapshotDialog" />
 
   <CodeGenerationDialog ref="codeGenerationDialog" />
@@ -220,6 +236,8 @@ defineExpose({
     @show-data-mapping-dialog="() => showDataMappingDialog()"
     @show-rml-mapping-dialog="() => showRmlMappingDialog()"
     @show-import-turtle-dialog="() => showTurtleImportDialog()"
+    @show-import-xml-dialog="() => showXmlImportDialog()"
+    @show-xml-export-dialog="() => showXmlExportDialog()"
     @mode-selected="newMode => emit('mode-selected', newMode)" />
 </template>
 

--- a/meta_configurator/src/components/toolbar/TopToolbar.vue
+++ b/meta_configurator/src/components/toolbar/TopToolbar.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import {ref} from 'vue';
+import {ref, watchEffect} from 'vue';
 import Button from 'primevue/button';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 import {useMagicKeys} from '@vueuse/core';
 import {focus} from '@/utility/focusUtils';
 import {SessionMode} from '@/store/sessionMode';
 import {useSettings} from '@/settings/useSettings';
+import {DataFormat} from '@/settings/settingsTypes';
 import Select from 'primevue/select';
 import {formatRegistry} from '@/dataformats/formatRegistry';
 import ModeSelector from '@/components/toolbar/ModeSelector.vue';
@@ -28,10 +29,18 @@ const emit = defineEmits<{
   (e: 'show-data-mapping-dialog'): void;
   (e: 'show-rml-mapping-dialog'): void;
   (e: 'show-import-turtle-dialog'): void;
+  (e: 'show-import-xml-dialog'): void;
+  (e: 'show-xml-export-dialog'): void;
 }>();
 
 const settings = useSettings();
 const dataFormatOptions = formatRegistry.getFormatNames();
+
+watchEffect(() => {
+  if (!dataFormatOptions.includes(settings.value.dataFormat)) {
+    settings.value.dataFormat = DataFormat.JSON;
+  }
+});
 
 async function showSchemaSelectionDialog() {
   emit('show-schema-selection-dialog');
@@ -73,6 +82,14 @@ function showTurtleImportDialog() {
   emit('show-import-turtle-dialog');
 }
 
+function showXmlImportDialog() {
+  emit('show-import-xml-dialog');
+}
+
+function showXmlExportDialog() {
+  emit('show-xml-export-dialog');
+}
+
 const modeSelector = ref();
 
 useMagicKeys({
@@ -110,7 +127,9 @@ useMagicKeys({
           @show-snapshot-dialog="() => showSnapshotDialog()"
           @show-data-mapping-dialog="() => showDataMappingDialog()"
           @show-rml-mapping-dialog="() => showRmlMappingDialog()"
-          @show-import-turtle-dialog="() => showTurtleImportDialog()" />
+          @show-import-turtle-dialog="() => showTurtleImportDialog()"
+          @show-import-xml-dialog="() => showXmlImportDialog()"
+          @show-xml-export-dialog="() => showXmlExportDialog()" />
 
         <Divider layout="vertical" />
 
@@ -175,7 +194,9 @@ useMagicKeys({
           @show-snapshot-dialog="() => showSnapshotDialog()"
           @show-data-mapping-dialog="() => showDataMappingDialog()"
           @show-rml-mapping-dialog="() => showRmlMappingDialog()"
-          @show-import-turtle-dialog="() => showTurtleImportDialog()" />
+          @show-import-turtle-dialog="() => showTurtleImportDialog()"
+          @show-import-xml-dialog="() => showXmlImportDialog()"
+          @show-xml-export-dialog="() => showXmlExportDialog()" />
       </div>
 
       <!-- RIGHT side: format selector -->

--- a/meta_configurator/src/components/toolbar/TopToolbarMenuButtons.vue
+++ b/meta_configurator/src/components/toolbar/TopToolbarMenuButtons.vue
@@ -26,6 +26,8 @@ const emit = defineEmits<{
   (e: 'show-data-mapping-dialog'): void;
   (e: 'show-rml-mapping-dialog'): void;
   (e: 'show-import-turtle-dialog'): void;
+  (e: 'show-import-xml-dialog'): void;
+  (e: 'show-xml-export-dialog'): void;
 }>();
 
 const settings = useSettings();
@@ -38,7 +40,9 @@ const topMenuBar = new MenuItems(
   showDataMappingDialog,
   inferSchemaFromSampleData,
   showRmlMappingDialog,
-  showTurtleImportDialog
+  showTurtleImportDialog,
+  showXmlImportDialog,
+  showXmlExportDialog
 );
 
 function showSchemaSelectionDialog() {
@@ -71,6 +75,14 @@ function showRmlMappingDialog() {
 
 function showTurtleImportDialog() {
   emit('show-import-turtle-dialog');
+}
+
+function showXmlImportDialog() {
+  emit('show-import-xml-dialog');
+}
+
+function showXmlExportDialog() {
+  emit('show-xml-export-dialog');
 }
 
 function inferSchemaFromSampleData() {

--- a/meta_configurator/src/components/toolbar/dialogs/xml-export/XmlExportDialog.vue
+++ b/meta_configurator/src/components/toolbar/dialogs/xml-export/XmlExportDialog.vue
@@ -1,0 +1,134 @@
+<!-- Dialog to configure and export data as XML -->
+<script setup lang="ts">
+import {reactive, ref} from 'vue';
+import Dialog from 'primevue/dialog';
+import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
+import InputNumber from 'primevue/inputnumber';
+import ToggleSwitch from 'primevue/toggleswitch';
+import {
+  DEFAULT_XML_EXPORT_OPTIONS,
+  exportXmlData,
+  type XmlExportOptions,
+} from '@/components/toolbar/dialogs/xml-export/exportXmlData';
+import {useSettings} from '@/settings/useSettings';
+import {toastService} from '@/utility/toastService';
+
+const showDialog = ref(false);
+const settings = useSettings();
+const exportOptions = reactive<XmlExportOptions>({...DEFAULT_XML_EXPORT_OPTIONS});
+
+function openDialog() {
+  Object.assign(exportOptions, {
+    ...DEFAULT_XML_EXPORT_OPTIONS,
+    attributeNamePrefix:
+      settings.value.textEditor.xml.attributeNamePrefix ||
+      DEFAULT_XML_EXPORT_OPTIONS.attributeNamePrefix,
+  });
+  showDialog.value = true;
+}
+
+function hideDialog() {
+  showDialog.value = false;
+}
+
+function performExport() {
+  try {
+    exportXmlData({...exportOptions});
+    hideDialog();
+  } catch (error) {
+    toastService.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: error,
+      life: 10000,
+    });
+  }
+}
+
+defineExpose({show: openDialog, close: hideDialog});
+</script>
+
+<template>
+  <Dialog
+    v-model:visible="showDialog"
+    header="Export XML"
+    :style="{maxWidth: '90%', minWidth: '40%', margin: 'auto'}">
+    <div class="bigger-dialog-content">
+      <div class="setting-row">
+        <label for="xml-attribute-prefix">Attribute prefix</label>
+        <InputText id="xml-attribute-prefix" v-model="exportOptions.attributeNamePrefix" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-text-node-name">Text node name</label>
+        <InputText id="xml-text-node-name" v-model="exportOptions.textNodeName" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-cdata-name">CDATA property name</label>
+        <InputText id="xml-cdata-name" v-model="exportOptions.cdataPropName" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-comment-name">Comment property name</label>
+        <InputText id="xml-comment-name" v-model="exportOptions.commentPropName" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-format-output">Pretty print</label>
+        <ToggleSwitch id="xml-format-output" v-model="exportOptions.format" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-indentation-spaces">Indentation spaces</label>
+        <InputNumber
+          id="xml-indentation-spaces"
+          v-model="exportOptions.indentationSpaces"
+          :min="0"
+          :max="8"
+          showButtons
+          :disabled="!exportOptions.format" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-suppress-empty-node">Use self-closing empty nodes</label>
+        <ToggleSwitch id="xml-suppress-empty-node" v-model="exportOptions.suppressEmptyNode" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-suppress-boolean-attributes">Suppress boolean attribute values</label>
+        <ToggleSwitch
+          id="xml-suppress-boolean-attributes"
+          v-model="exportOptions.suppressBooleanAttributes" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-one-list-group">Group repeated array items</label>
+        <ToggleSwitch id="xml-one-list-group" v-model="exportOptions.oneListGroup" />
+      </div>
+
+      <Button label="Export" icon="pi pi-download" @click="performExport" />
+    </div>
+  </Dialog>
+</template>
+
+<style scoped>
+.bigger-dialog-content {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.setting-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.setting-row label {
+  font-weight: 600;
+}
+</style>

--- a/meta_configurator/src/components/toolbar/dialogs/xml-export/__tests__/exportXmlData.test.ts
+++ b/meta_configurator/src/components/toolbar/dialogs/xml-export/__tests__/exportXmlData.test.ts
@@ -1,0 +1,121 @@
+import {describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/data/dataSource', () => ({
+  useDataSource: () => ({
+    userSchemaData: {
+      value: {
+        title: 'test',
+      },
+    },
+  }),
+}));
+
+vi.mock('@/data/useDataLink', () => ({
+  useCurrentData: () => ({
+    data: {
+      value: {},
+    },
+  }),
+}));
+
+import {
+  DEFAULT_XML_EXPORT_OPTIONS,
+  jsonToXmlDataWithOptions,
+} from '@/components/toolbar/dialogs/xml-export/exportXmlData';
+
+describe('jsonToXmlDataWithOptions', () => {
+  it('uses the configured attribute prefix', () => {
+    const result = jsonToXmlDataWithOptions(
+      {root: {$id: '1', child: 'value'}},
+      {
+        ...DEFAULT_XML_EXPORT_OPTIONS,
+        attributeNamePrefix: '$',
+      }
+    );
+
+    expect(result).toContain('<root id="1">');
+    expect(result).toContain('<child>value</child>');
+  });
+
+  it('uses the configured text node name', () => {
+    const result = jsonToXmlDataWithOptions(
+      {root: {value: 'text'}},
+      {
+        ...DEFAULT_XML_EXPORT_OPTIONS,
+        textNodeName: 'value',
+      }
+    );
+
+    expect(result).toBe('<root>text</root>\n');
+  });
+
+  it('uses the configured CDATA and comment property names', () => {
+    const result = jsonToXmlDataWithOptions(
+      {root: {cdata: 'raw', comment: 'note'}},
+      {
+        ...DEFAULT_XML_EXPORT_OPTIONS,
+        cdataPropName: 'cdata',
+        commentPropName: 'comment',
+      }
+    );
+
+    expect(result).toContain('<![CDATA[raw]]>');
+    expect(result).toContain('<!--note-->');
+  });
+
+  it('uses the configured indentation space count', () => {
+    const result = jsonToXmlDataWithOptions(
+      {root: {child: 'value'}},
+      {
+        ...DEFAULT_XML_EXPORT_OPTIONS,
+        indentationSpaces: 4,
+      }
+    );
+
+    expect(result).toContain('\n    <child>value</child>');
+  });
+
+  it('controls empty node suppression', () => {
+    const suppressed = jsonToXmlDataWithOptions(
+      {root: {empty: ''}},
+      {
+        ...DEFAULT_XML_EXPORT_OPTIONS,
+        format: false,
+        suppressEmptyNode: true,
+      }
+    );
+    const expanded = jsonToXmlDataWithOptions(
+      {root: {empty: ''}},
+      {
+        ...DEFAULT_XML_EXPORT_OPTIONS,
+        format: false,
+        suppressEmptyNode: false,
+      }
+    );
+
+    expect(suppressed).toBe('<root><empty/></root>');
+    expect(expanded).toBe('<root><empty></empty></root>');
+  });
+
+  it('controls boolean attribute value suppression', () => {
+    const withValue = jsonToXmlDataWithOptions(
+      {root: {_disabled: true}},
+      {
+        ...DEFAULT_XML_EXPORT_OPTIONS,
+        format: false,
+        suppressBooleanAttributes: false,
+      }
+    );
+    const withoutValue = jsonToXmlDataWithOptions(
+      {root: {_disabled: true}},
+      {
+        ...DEFAULT_XML_EXPORT_OPTIONS,
+        format: false,
+        suppressBooleanAttributes: true,
+      }
+    );
+
+    expect(withValue).toBe('<root disabled="true"/>');
+    expect(withoutValue).toBe('<root disabled/>');
+  });
+});

--- a/meta_configurator/src/components/toolbar/dialogs/xml-export/exportXmlData.ts
+++ b/meta_configurator/src/components/toolbar/dialogs/xml-export/exportXmlData.ts
@@ -1,0 +1,70 @@
+import {XMLBuilder, type XmlBuilderOptions} from 'fast-xml-parser';
+import {useDataSource} from '@/data/dataSource';
+import {useCurrentData} from '@/data/useDataLink';
+
+export interface XmlExportOptions {
+  attributeNamePrefix: string;
+  textNodeName: string;
+  cdataPropName: string;
+  commentPropName: string;
+  format: boolean;
+  indentationSpaces: number;
+  suppressEmptyNode: boolean;
+  suppressBooleanAttributes: boolean;
+  oneListGroup: boolean;
+}
+
+export const DEFAULT_XML_EXPORT_OPTIONS: XmlExportOptions = {
+  attributeNamePrefix: '_',
+  textNodeName: '#text',
+  cdataPropName: '#cdata',
+  commentPropName: '#comment',
+  format: true,
+  indentationSpaces: 2,
+  suppressEmptyNode: true,
+  suppressBooleanAttributes: false,
+  oneListGroup: false,
+};
+
+export function exportXmlData(options: XmlExportOptions): void {
+  const xmlContent = jsonToXmlDataWithOptions(useCurrentData().data.value, options);
+  downloadXmlContent(xmlContent, useDataSource().userSchemaData.value.title ?? 'untitled');
+}
+
+export function jsonToXmlDataWithOptions(data: any, options: XmlExportOptions): string {
+  const builder = new XMLBuilder(createXmlBuilderOptions(options));
+  return builder.build(data);
+}
+
+function createXmlBuilderOptions(options: XmlExportOptions): XmlBuilderOptions {
+  return {
+    attributesGroupName: false,
+    attributeNamePrefix: options.attributeNamePrefix,
+    textNodeName: options.textNodeName,
+    ignoreAttributes: false,
+    cdataPropName: options.cdataPropName || false,
+    commentPropName: options.commentPropName || false,
+    processEntities: true,
+    preserveOrder: false,
+    format: options.format,
+    indentBy: ' '.repeat(options.indentationSpaces),
+    arrayNodeName: undefined,
+    suppressEmptyNode: options.suppressEmptyNode,
+    suppressUnpairedNode: false,
+    suppressBooleanAttributes: options.suppressBooleanAttributes,
+    unpairedTags: [],
+    stopNodes: [],
+    oneListGroup: options.oneListGroup,
+  };
+}
+
+function downloadXmlContent(content: string, fileNamePrefix: string): void {
+  const blob = new Blob([content], {type: 'application/xml'});
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = `${fileNamePrefix}.xml`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}

--- a/meta_configurator/src/components/toolbar/dialogs/xml-import/ImportXmlDialog.vue
+++ b/meta_configurator/src/components/toolbar/dialogs/xml-import/ImportXmlDialog.vue
@@ -1,0 +1,170 @@
+<!-- Dialog to import XML data -->
+<script setup lang="ts">
+import {reactive, type Ref, ref, watch} from 'vue';
+import Dialog from 'primevue/dialog';
+import Button from 'primevue/button';
+import Message from 'primevue/message';
+import InputText from 'primevue/inputtext';
+import ToggleSwitch from 'primevue/toggleswitch';
+import {
+  DEFAULT_XML_IMPORT_OPTIONS,
+  requestUploadXmlFileToRef,
+  type XmlImportOptions,
+  xmlToJsonDataWithOptions,
+} from '@/components/toolbar/dialogs/xml-import/importXmlUtils';
+import {useCurrentData} from '@/data/useDataLink';
+import {toastService} from '@/utility/toastService';
+import {useSettings} from '@/settings/useSettings';
+
+const isLoading = ref(false);
+const showDialog = ref(false);
+const currentUserDataString: Ref<string> = ref('');
+const settings = useSettings();
+const importOptions = reactive<XmlImportOptions>({...DEFAULT_XML_IMPORT_OPTIONS});
+
+function openDialog() {
+  Object.assign(importOptions, {
+    ...DEFAULT_XML_IMPORT_OPTIONS,
+    attributeNamePrefix:
+      settings.value.textEditor.xml.attributeNamePrefix ||
+      DEFAULT_XML_IMPORT_OPTIONS.attributeNamePrefix,
+  });
+  showDialog.value = true;
+}
+
+function hideDialog() {
+  showDialog.value = false;
+}
+
+function requestUploadFile() {
+  requestUploadXmlFileToRef(currentUserDataString);
+}
+
+function importXmlData(xml: string): void {
+  isLoading.value = true;
+  try {
+    useCurrentData().setData(xmlToJsonDataWithOptions(xml, {...importOptions}));
+    toastService.add({
+      severity: 'info',
+      summary: 'Successful',
+      detail: 'XML import finished.',
+      life: 3000,
+    });
+  } catch (error) {
+    toastService.add({
+      severity: 'error',
+      summary: 'Error',
+      detail: error,
+      life: 10000,
+    });
+  } finally {
+    isLoading.value = false;
+    hideDialog();
+    currentUserDataString.value = '';
+  }
+}
+
+watch(currentUserDataString, newValue => {
+  if (newValue) importXmlData(newValue);
+});
+
+defineExpose({show: openDialog, close: hideDialog});
+</script>
+<template>
+  <Dialog v-model:visible="showDialog" header="Import XML">
+    <div
+      class="flex flex-column gap-3 bigger-dialog-content"
+      :style="{cursor: isLoading ? 'wait' : 'default'}">
+      <Message severity="warn" :closable="false" icon="pi pi-exclamation-triangle">
+        Importing an XML file will overwrite your existing data. <br />
+        The schema will remain unchanged.
+      </Message>
+
+      <div class="setting-row">
+        <label for="xml-import-attribute-prefix">Attribute prefix</label>
+        <InputText id="xml-import-attribute-prefix" v-model="importOptions.attributeNamePrefix" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-text-node-name">Text node name</label>
+        <InputText id="xml-import-text-node-name" v-model="importOptions.textNodeName" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-cdata-name">CDATA property name</label>
+        <InputText id="xml-import-cdata-name" v-model="importOptions.cdataPropName" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-comment-name">Comment property name</label>
+        <InputText id="xml-import-comment-name" v-model="importOptions.commentPropName" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-trim-values">Trim values</label>
+        <ToggleSwitch id="xml-import-trim-values" v-model="importOptions.trimValues" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-boolean-attributes">Allow boolean attributes</label>
+        <ToggleSwitch
+          id="xml-import-boolean-attributes"
+          v-model="importOptions.allowBooleanAttributes" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-parse-tag-value">Parse tag values</label>
+        <ToggleSwitch id="xml-import-parse-tag-value" v-model="importOptions.parseTagValue" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-parse-attribute-value">Parse attribute values</label>
+        <ToggleSwitch
+          id="xml-import-parse-attribute-value"
+          v-model="importOptions.parseAttributeValue" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-remove-ns-prefix">Remove namespace prefixes</label>
+        <ToggleSwitch id="xml-import-remove-ns-prefix" v-model="importOptions.removeNSPrefix" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-always-text-node">Always create text nodes</label>
+        <ToggleSwitch
+          id="xml-import-always-text-node"
+          v-model="importOptions.alwaysCreateTextNode" />
+      </div>
+
+      <div class="setting-row">
+        <label for="xml-import-process-entities">Process entities</label>
+        <ToggleSwitch id="xml-import-process-entities" v-model="importOptions.processEntities" />
+      </div>
+
+      <div class="flex align-items-center justify-content-center gap-2">
+        <Button label="Select File" @click="requestUploadFile" :disabled="isLoading" />
+      </div>
+
+      <div v-if="isLoading" class="mt-3 text-sm text-gray-500">Importing, please wait...</div>
+    </div>
+  </Dialog>
+</template>
+
+<style scoped>
+.bigger-dialog-content {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.setting-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.setting-row label {
+  font-weight: 600;
+}
+</style>

--- a/meta_configurator/src/components/toolbar/dialogs/xml-import/__tests__/importXmlUtils.test.ts
+++ b/meta_configurator/src/components/toolbar/dialogs/xml-import/__tests__/importXmlUtils.test.ts
@@ -1,0 +1,71 @@
+import {describe, expect, it} from 'vitest';
+import {
+  DEFAULT_XML_IMPORT_OPTIONS,
+  xmlToJsonDataWithOptions,
+} from '@/components/toolbar/dialogs/xml-import/importXmlUtils';
+
+describe('xmlToJsonDataWithOptions', () => {
+  it('uses the configured attribute prefix', () => {
+    const result = xmlToJsonDataWithOptions('<root id="1" />', {
+      ...DEFAULT_XML_IMPORT_OPTIONS,
+      attributeNamePrefix: '$',
+    });
+
+    expect(result).toEqual({root: {$id: '1'}});
+  });
+
+  it('parses tag and attribute values when enabled', () => {
+    const result = xmlToJsonDataWithOptions('<root id="1"><child>42</child></root>', {
+      ...DEFAULT_XML_IMPORT_OPTIONS,
+      parseTagValue: true,
+      parseAttributeValue: true,
+    });
+
+    expect(result).toEqual({root: {child: 42, _id: 1}});
+  });
+
+  it('keeps surrounding whitespace when trim values is disabled', () => {
+    const result = xmlToJsonDataWithOptions('<root>  spaced  </root>', {
+      ...DEFAULT_XML_IMPORT_OPTIONS,
+      trimValues: false,
+    });
+
+    expect(result).toEqual({root: '  spaced  '});
+  });
+
+  it('removes namespace prefixes when enabled', () => {
+    const result = xmlToJsonDataWithOptions('<ns:root><ns:item>value</ns:item></ns:root>', {
+      ...DEFAULT_XML_IMPORT_OPTIONS,
+      removeNSPrefix: true,
+    });
+
+    expect(result).toEqual({root: {item: 'value'}});
+  });
+
+  it('uses configured text, comment, and CDATA property names', () => {
+    const result = xmlToJsonDataWithOptions(
+      '<root><!--note--><![CDATA[raw]]><value>text</value></root>',
+      {
+        ...DEFAULT_XML_IMPORT_OPTIONS,
+        textNodeName: 'text',
+        commentPropName: 'comment',
+        cdataPropName: 'cdata',
+        alwaysCreateTextNode: true,
+      }
+    );
+
+    expect(result).toEqual({
+      root: {
+        comment: {
+          text: 'note',
+        },
+        cdata: {
+          text: 'raw',
+        },
+        value: {
+          text: 'text',
+        },
+      },
+    });
+  });
+});

--- a/meta_configurator/src/components/toolbar/dialogs/xml-import/importXmlUtils.ts
+++ b/meta_configurator/src/components/toolbar/dialogs/xml-import/importXmlUtils.ts
@@ -1,0 +1,64 @@
+import {readFileContentToStringRef} from '@/utility/readFileContent';
+import type {Ref} from 'vue';
+import {createLazySingleFileDialog} from '@/utility/fileDialogUtils';
+import {XMLParser, type X2jOptions} from 'fast-xml-parser';
+
+const xmlFileDialog = createLazySingleFileDialog('.xml');
+
+export interface XmlImportOptions {
+  attributeNamePrefix: string;
+  textNodeName: string;
+  cdataPropName: string;
+  commentPropName: string;
+  trimValues: boolean;
+  allowBooleanAttributes: boolean;
+  parseTagValue: boolean;
+  parseAttributeValue: boolean;
+  removeNSPrefix: boolean;
+  alwaysCreateTextNode: boolean;
+  processEntities: boolean;
+}
+
+export const DEFAULT_XML_IMPORT_OPTIONS: XmlImportOptions = {
+  attributeNamePrefix: '_',
+  textNodeName: '#text',
+  cdataPropName: '#cdata',
+  commentPropName: '#comment',
+  trimValues: true,
+  allowBooleanAttributes: true,
+  parseTagValue: false,
+  parseAttributeValue: false,
+  removeNSPrefix: false,
+  alwaysCreateTextNode: false,
+  processEntities: true,
+};
+
+export function requestUploadXmlFileToRef(resultString: Ref<string>): void {
+  xmlFileDialog.openForSelection(files => {
+    readFileContentToStringRef(files, resultString);
+  });
+}
+
+export function xmlToJsonDataWithOptions(xmlString: string, options: XmlImportOptions): any {
+  const parser = new XMLParser(createXmlParserOptions(options));
+  return parser.parse(xmlString);
+}
+
+function createXmlParserOptions(options: XmlImportOptions): X2jOptions {
+  return {
+    attributesGroupName: false,
+    attributeNamePrefix: options.attributeNamePrefix,
+    textNodeName: options.textNodeName,
+    ignoreAttributes: false,
+    removeNSPrefix: options.removeNSPrefix,
+    allowBooleanAttributes: options.allowBooleanAttributes,
+    parseTagValue: options.parseTagValue,
+    parseAttributeValue: options.parseAttributeValue,
+    trimValues: options.trimValues,
+    cdataPropName: options.cdataPropName || false,
+    commentPropName: options.commentPropName || false,
+    alwaysCreateTextNode: options.alwaysCreateTextNode,
+    processEntities: options.processEntities,
+    preserveOrder: false,
+  };
+}

--- a/meta_configurator/src/components/toolbar/menuItems.ts
+++ b/meta_configurator/src/components/toolbar/menuItems.ts
@@ -31,6 +31,8 @@ export class MenuItems {
   private readonly inferJsonSchemaFromSampleData: () => void;
   private readonly showRMLMappingDialog: () => void;
   private readonly showImportTurtleDialog: () => void;
+  private readonly showImportXmlDialog: () => void;
+  private readonly showXmlExportDialog: () => void;
 
   constructor(
     showSchemaSelectionDialog: () => void,
@@ -41,7 +43,9 @@ export class MenuItems {
     showDataMappingDialog: () => void,
     inferJsonSchemaFromSampleData: () => void,
     showRMLMappingDialog: () => void,
-    showImportTurtleDialog: () => void
+    showImportTurtleDialog: () => void,
+    showImportXmlDialog: () => void,
+    showXmlExportDialog: () => void
   ) {
     this.showSchemaSelectionDialog = showSchemaSelectionDialog;
     this.showImportCsvDialog = showImportCsvDialog;
@@ -52,6 +56,8 @@ export class MenuItems {
     this.inferJsonSchemaFromSampleData = inferJsonSchemaFromSampleData;
     this.showRMLMappingDialog = showRMLMappingDialog;
     this.showImportTurtleDialog = showImportTurtleDialog;
+    this.showImportXmlDialog = showImportXmlDialog;
+    this.showXmlExportDialog = showXmlExportDialog;
   }
 
   public getDataEditorMenuItems(settings: SettingsInterfaceRoot): MenuItem[] {
@@ -92,6 +98,11 @@ export class MenuItems {
             icon: 'fa-solid fa-globe',
             command: this.showImportTurtleDialog,
           },
+          {
+            label: 'Import XML Data',
+            icon: 'fa-solid fa-file-code',
+            command: this.showImportXmlDialog,
+          },
         ],
       },
       {
@@ -99,6 +110,17 @@ export class MenuItems {
         icon: 'fa-solid fa-download',
         command: () =>
           downloadFile(useDataSource().userSchemaData.value.title ?? 'untitled', false),
+      },
+      {
+        label: 'Export Data...',
+        icon: 'fa-solid fa-file-export',
+        items: [
+          {
+            label: 'Export to XML',
+            icon: 'fa-solid fa-file-code',
+            command: this.showXmlExportDialog,
+          },
+        ],
       },
       {
         label: 'Utility...',

--- a/meta_configurator/src/dataformats/defaultFormats.ts
+++ b/meta_configurator/src/dataformats/defaultFormats.ts
@@ -1,5 +1,5 @@
 import type {DataFormatDefinition} from '@/dataformats/dataFormatDefinition';
-import {DataConverterJson, DataConverterXml, DataConverterYaml} from '@/dataformats/dataConverter';
+import {DataConverterJson, DataConverterYaml} from '@/dataformats/dataConverter';
 import {PathIndexLinkJson} from '@/dataformats/pathIndexLinkJson';
 import {formatRegistry} from '@/dataformats/formatRegistry';
 import {PathIndexLinkYaml} from '@/dataformats/pathIndexLinkYaml';
@@ -14,16 +14,10 @@ const yamlFormat: DataFormatDefinition = {
   pathIndexLink: new PathIndexLinkYaml(),
 };
 
-const xmlFormat: DataFormatDefinition = {
-  dataConverter: new DataConverterXml(),
-  pathIndexLink: null,
-};
-
 /**
  * Registers the default data formats, which are JSON and YAML.
  */
 export function registerDefaultDataFormats() {
   formatRegistry.registerFormat('json', jsonFormat);
   formatRegistry.registerFormat('yaml', yamlFormat);
-  formatRegistry.registerFormat('xml', xmlFormat);
 }

--- a/meta_configurator/src/settings/settingsSchema.ts
+++ b/meta_configurator/src/settings/settingsSchema.ts
@@ -45,7 +45,7 @@ export const SETTINGS_SCHEMA: TopLevelSchema = {
       type: 'string',
       description: 'The data format to use for the configuration files.',
       default: 'json',
-      enum: ['json', 'yaml', 'xml'],
+      enum: ['json', 'yaml'],
     },
     toolbarTitle: {
       type: 'string',

--- a/meta_configurator/src/settings/settingsTypes.ts
+++ b/meta_configurator/src/settings/settingsTypes.ts
@@ -104,7 +104,6 @@ export enum PropertySorting {
 export enum DataFormat {
   JSON = 'json',
   YAML = 'yaml',
-  XML = 'xml',
 }
 
 export interface SettingsInterfaceBackend {

--- a/tests/shared/utils.ts
+++ b/tests/shared/utils.ts
@@ -2,7 +2,7 @@ import {modeToMenuTitle, modeToRoute, SessionMode} from "../../meta_configurator
 import {expect, type Page} from "./playwright";
 import * as os from "node:os";
 
-const dataFormats = [ 'json', 'yaml', 'xml' ];
+const dataFormats = [ 'json', 'yaml' ];
 
 
 export async function getCurrentEditorMode(page: Page): Promise<SessionMode> {


### PR DESCRIPTION
**What was done:**

remove XML as dataformat and instead introduce XML import and XML export

**Why:**

The conversion from JSON to XML is often not reversible and the other way around also not. 
MetaConfigurator internally stores all data and schema in JSON. Even when visually an XML document was edited, the underlaying data was stored as JSON. This is prone to lead to inconsistencies and bugs.



