### PR TITLE
show library info for schema conversion paths

### DIFF
--- a/meta_configurator/src/components/toolbar/dialogs/schema-conversion/ConversionAttemptView.vue
+++ b/meta_configurator/src/components/toolbar/dialogs/schema-conversion/ConversionAttemptView.vue
@@ -58,9 +58,29 @@ function copyError() {
         <span
           class="path-edge"
           :class="{'edge-failed': i === failedIndex}"
-          :title="i === failedIndex ? 'This step failed — see the error below' : undefined">
-          <span class="converter-name" :title="step.converterName">{{ step.converterName }}</span>
+          tabindex="0">
+          <span class="converter-name">{{ step.converterName }}</span>
           <span class="arrow">→</span>
+          <!-- Rich hover/focus tooltip: library name, version and clickable link. -->
+          <span class="edge-tooltip" role="tooltip">
+            <span class="tooltip-converter">{{ step.converterName }}</span>
+            <span v-if="step.library" class="tooltip-library">
+              Library: {{ step.library
+              }}<template v-if="step.libraryVersion"> v{{ step.libraryVersion }}</template>
+            </span>
+            <span v-else class="tooltip-library tooltip-muted">Library: unknown</span>
+            <a
+              v-if="step.libraryUrl"
+              class="tooltip-link"
+              :href="step.libraryUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              >{{ step.libraryUrl }}</a
+            >
+            <span v-if="i === failedIndex" class="tooltip-failed"
+              >This step failed — see the error below.</span
+            >
+          </span>
         </span>
         <span
           v-if="i === attempt.conversionPath.length - 1"
@@ -144,6 +164,9 @@ function copyError() {
   flex-direction: column;
   align-items: center;
   line-height: 1.1;
+  position: relative;
+  cursor: help;
+  outline: none;
 }
 
 .converter-name {
@@ -153,6 +176,94 @@ function copyError() {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Rich tooltip shown above the edge on hover/focus; stays interactive so the
+   library link can be clicked (it is a descendant, so :hover persists). */
+.edge-tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 11rem;
+  max-width: 22rem;
+  margin-bottom: 6px;
+  padding: 0.5rem 0.6rem;
+  background: var(--p-surface-900, #111827);
+  color: var(--p-surface-0, #f9fafb);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  font-size: 0.72rem;
+  text-align: left;
+  white-space: normal;
+  word-break: break-word;
+  z-index: 30;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.1s ease-in-out;
+}
+
+.path-edge:hover .edge-tooltip,
+.path-edge:focus-within .edge-tooltip,
+.path-edge:focus .edge-tooltip {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Caret pointing down at the edge; also bridges the 6px gap so moving the
+   cursor into the tooltip does not dismiss it. */
+.edge-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 16px;
+  height: 6px;
+  transform: translateX(-50%);
+  background: transparent;
+}
+
+.edge-tooltip::before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--p-surface-900, #111827);
+}
+
+.tooltip-converter {
+  font-weight: 700;
+}
+
+.tooltip-library {
+  color: var(--p-surface-200, #e5e7eb);
+}
+
+.tooltip-muted {
+  font-style: italic;
+  opacity: 0.85;
+}
+
+.tooltip-link {
+  color: var(--p-primary-300, #93c5fd);
+  text-decoration: underline;
+  word-break: break-all;
+}
+
+.tooltip-link:hover {
+  text-decoration: underline;
+  filter: brightness(1.15);
+}
+
+.tooltip-failed {
+  margin-top: 0.15rem;
+  color: var(--p-red-300, #fca5a5);
+  font-weight: 600;
 }
 
 .arrow {

--- a/meta_configurator/src/components/toolbar/dialogs/schema-conversion/ConversionAttemptView.vue
+++ b/meta_configurator/src/components/toolbar/dialogs/schema-conversion/ConversionAttemptView.vue
@@ -55,10 +55,7 @@ function copyError() {
       <span class="attempt-rank">#{{ index + 1 }}</span>
       <template v-for="(step, i) in attempt.conversionPath" :key="i">
         <span class="lang-node">{{ languageLabel(step.sourceLanguage) }}</span>
-        <span
-          class="path-edge"
-          :class="{'edge-failed': i === failedIndex}"
-          tabindex="0">
+        <span class="path-edge" :class="{'edge-failed': i === failedIndex}" tabindex="0">
           <span class="converter-name">{{ step.converterName }}</span>
           <span class="arrow">→</span>
           <!-- Rich hover/focus tooltip: library name, version and clickable link. -->

--- a/meta_configurator/src/components/toolbar/dialogs/schema-conversion/__tests__/conversionAttemptView.test.ts
+++ b/meta_configurator/src/components/toolbar/dialogs/schema-conversion/__tests__/conversionAttemptView.test.ts
@@ -73,10 +73,11 @@ describe('ConversionAttemptView', () => {
     expect(wrapper.find('.action-slot').exists()).toBe(false);
   });
 
-  it('highlights the failing edge in red based on the error message', () => {
+  it('highlights the failing edge in red based on the backend failedStepIndex', () => {
     const wrapper = mountView({
       success: false,
       result: 'Conversion failed at step from MdModels to Shex via FlaskApp because of error: boom',
+      failedStepIndex: 1,
       conversionPath: [
         step('Xsd', 'MdModels', 'FlaskApp', 'xsd2md'),
         step('MdModels', 'Shex', 'FlaskApp', 'md2shex'),
@@ -89,12 +90,49 @@ describe('ConversionAttemptView', () => {
     expect(edges[1]!.classes()).toContain('edge-failed');
   });
 
-  it('does not highlight any edge when the failing step cannot be determined', () => {
+  it('does not highlight any edge when the backend did not pinpoint a step', () => {
     const wrapper = mountView({
       success: false,
       result: 'an opaque error with no step info',
+      failedStepIndex: null,
       conversionPath: [step('Xsd', 'JsonSchema', 'FlaskApp', 'xsd2js')],
     });
     expect(wrapper.findAll('.edge-failed')).toHaveLength(0);
+  });
+
+  it('shows the library name, version and clickable url in the edge tooltip', () => {
+    const wrapper = mountView({
+      success: true,
+      result: 'ok',
+      conversionPath: [
+        {
+          sourceLanguage: 'Xsd',
+          targetLanguage: 'JsonSchema',
+          serviceName: 'FlaskApp',
+          converterName: 'xsd2js',
+          library: 'xsd2jsonschema',
+          libraryVersion: '0.3.7',
+          libraryUrl: 'https://www.npmjs.com/package/xsd2jsonschema',
+        },
+      ],
+    });
+    const tooltip = wrapper.find('.edge-tooltip');
+    expect(tooltip.exists()).toBe(true);
+    expect(tooltip.text()).toContain('xsd2jsonschema');
+    expect(tooltip.text()).toContain('v0.3.7');
+    const link = tooltip.find('a.tooltip-link');
+    expect(link.exists()).toBe(true);
+    expect(link.attributes('href')).toBe('https://www.npmjs.com/package/xsd2jsonschema');
+  });
+
+  it('falls back to "Library: unknown" when no library metadata is present', () => {
+    const wrapper = mountView({
+      success: true,
+      result: 'ok',
+      conversionPath: [step('Xsd', 'JsonSchema', 'FlaskApp', 'xsd2js')],
+    });
+    const tooltip = wrapper.find('.edge-tooltip');
+    expect(tooltip.text()).toContain('Library: unknown');
+    expect(tooltip.find('a.tooltip-link').exists()).toBe(false);
   });
 });

--- a/meta_configurator/src/utility/backend/__tests__/schemaConverterApi.test.ts
+++ b/meta_configurator/src/utility/backend/__tests__/schemaConverterApi.test.ts
@@ -31,8 +31,12 @@ function ok(result: string, path = [step('Xsd', 'JsonSchema')]): ConversionAttem
   return {success: true, result, conversionPath: path};
 }
 
-function fail(result: string, path = [step('Xsd', 'JsonSchema')]): ConversionAttempt {
-  return {success: false, result, conversionPath: path};
+function fail(
+  result: string,
+  path = [step('Xsd', 'JsonSchema')],
+  failedStepIndex: number | null = null
+): ConversionAttempt {
+  return {success: false, result, conversionPath: path, failedStepIndex};
 }
 
 function jsonResponse(body: unknown, {okFlag = true, status = 200} = {}): Response {
@@ -131,20 +135,17 @@ describe('failedStepIndex', () => {
     expect(failedStepIndex(ok('whatever'))).toBe(-1);
   });
 
-  it('identifies the failing edge from the backend error message', () => {
+  it('returns the failing edge index reported by the backend', () => {
     const path = [
       step('Xsd', 'MdModels', 'FlaskApp', 'xsd2md'),
       step('MdModels', 'Shex', 'FlaskApp', 'md2shex'),
     ];
-    const attempt = fail(
-      'Conversion failed at step from MdModels to Shex via FlaskApp because of error: boom',
-      path
-    );
+    const attempt = fail('boom', path, 1);
     expect(failedStepIndex(attempt)).toBe(1);
   });
 
-  it('returns -1 when the error message does not match the known format', () => {
-    expect(failedStepIndex(fail('some unrelated error'))).toBe(-1);
+  it('returns -1 when the backend did not pinpoint a step', () => {
+    expect(failedStepIndex(fail('some unrelated error', undefined, null))).toBe(-1);
   });
 });
 

--- a/meta_configurator/src/utility/backend/schemaConverterApi.ts
+++ b/meta_configurator/src/utility/backend/schemaConverterApi.ts
@@ -24,6 +24,12 @@ export interface ConversionStep {
   targetLanguage: string;
   serviceName: string;
   converterName: string;
+  /** Underlying library that performs this step (e.g. "linkml"), if known. */
+  library?: string | null;
+  /** Installed version of that library, if known. */
+  libraryVersion?: string | null;
+  /** Link to the library's homepage / package page, if known. */
+  libraryUrl?: string | null;
 }
 
 /** A single conversion attempt along one path. */
@@ -32,6 +38,11 @@ export interface ConversionAttempt {
   /** Converted schema when `success`, otherwise the error message. */
   result: string;
   conversionPath: ConversionStep[];
+  /**
+   * 0-based index into `conversionPath` of the step that caused the failure,
+   * or null for successful attempts (and failures without a specific step).
+   */
+  failedStepIndex?: number | null;
 }
 
 /** A schema language as understood by the converter, plus UI metadata. */
@@ -119,34 +130,16 @@ export function selectDisplayedAttempts(
 }
 
 /**
- * For a failed attempt, determine which step (edge) of the path caused the
- * failure, so it can be highlighted. The backend embeds this in the error
- * message ("... failed at step from <source> to <target> via <service> ..."),
- * which we match against the conversion path. Returns -1 if it cannot be
- * determined (or the attempt succeeded).
+ * For a failed attempt, the index of the path step (edge) that caused the
+ * failure, so it can be highlighted. The backend reports this directly as
+ * `failedStepIndex`. Returns -1 when the attempt succeeded or the backend did
+ * not pinpoint a step.
  */
 export function failedStepIndex(attempt: ConversionAttempt): number {
-  if (attempt.success) {
+  if (attempt.success || attempt.failedStepIndex == null) {
     return -1;
   }
-  const match = /failed at step from (\S+) to (\S+) via (.+?) because of error/i.exec(
-    attempt.result ?? ''
-  );
-  if (!match) {
-    return -1;
-  }
-  const source = match[1];
-  const target = match[2];
-  const service = match[3];
-  if (!source || !target || !service) {
-    return -1;
-  }
-  return attempt.conversionPath.findIndex(
-    step =>
-      step.sourceLanguage === source &&
-      step.targetLanguage === target &&
-      step.serviceName === service.trim()
-  );
+  return attempt.failedStepIndex;
 }
 
 /** Default file extension to suggest when downloading a converted schema. */


### PR DESCRIPTION
**What was done:**

show library info for schema conversion paths

**Why:**

In case of errors in a path, it is easy to trace back the exact library and version responsible for the error.