### PR TITLE
1022 ai assisted schema editing handling of references

### DIFF
--- a/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
@@ -214,8 +214,6 @@ function processResult(
   }
 }
 
-
-
 function applyEditorDocument() {
   try {
     const dataFormat = settings.value.dataFormat;

--- a/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
@@ -25,8 +25,7 @@ import {
 import {fetchExternalContentText} from '@/utility/fetchExternalContent';
 import Panel from 'primevue/panel';
 import {removeCustomFieldsFromSchema} from '@/components/panels/ai-prompts/schemaProcessor';
-import {extractGeneratedDefinitionsFromSubSchema} from '@/schema/schemaManipulationUtils';
-import type {ManagedData} from '@/data/managedData';
+import {postProcessSchemaModification} from '@/schema/schemaManipulationUtils';
 
 const props = defineProps<{
   sessionMode: SessionMode;
@@ -215,12 +214,7 @@ function processResult(
   }
 }
 
-function postProcessSchemaModification(responseObject: any, schemaData: ManagedData): any {
-  if (responseObject === null || typeof responseObject !== 'object') {
-    return responseObject;
-  }
-  return extractGeneratedDefinitionsFromSubSchema(responseObject, schemaData);
-}
+
 
 function applyEditorDocument() {
   try {

--- a/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
@@ -28,7 +28,6 @@ import {removeCustomFieldsFromSchema} from '@/components/panels/ai-prompts/schem
 import {extractGeneratedDefinitionsFromSubSchema} from '@/schema/schemaManipulationUtils';
 import type {ManagedData} from '@/data/managedData';
 
-
 const props = defineProps<{
   sessionMode: SessionMode;
   defaultTextCreateDocument: string;

--- a/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
@@ -25,6 +25,9 @@ import {
 import {fetchExternalContentText} from '@/utility/fetchExternalContent';
 import Panel from 'primevue/panel';
 import {removeCustomFieldsFromSchema} from '@/components/panels/ai-prompts/schemaProcessor';
+import {extractGeneratedDefinitionsFromSubSchema} from '@/schema/schemaManipulationUtils';
+import type {ManagedData} from '@/data/managedData';
+
 
 const props = defineProps<{
   sessionMode: SessionMode;
@@ -202,14 +205,22 @@ function processResult(
   pathForResponse: Path
 ) {
   if (validJson) {
-    // if the response is valid, it is applied directly
+    if (data.mode === SessionMode.SchemaEditor && pathForResponse.length > 0) {
+      responseObject = postProcessSchemaModification(responseObject, data);
+    }
     newDocument.value = '';
     data.setDataAt(pathForResponse, responseObject);
   } else {
-    // otherwise, the invalid response is shown to the user, who can try to figure out what went wrong and fix it
     newDocument.value = response;
     newDocumentPath.value = pathForResponse;
   }
+}
+
+function postProcessSchemaModification(responseObject: any, schemaData: ManagedData): any {
+  if (responseObject === null || typeof responseObject !== 'object') {
+    return responseObject;
+  }
+  return extractGeneratedDefinitionsFromSubSchema(responseObject, schemaData);
 }
 
 function applyEditorDocument() {

--- a/meta_configurator/src/schema/__tests__/extractDefinitions.test.ts
+++ b/meta_configurator/src/schema/__tests__/extractDefinitions.test.ts
@@ -120,7 +120,7 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
         contact: {$ref: '#/$defs/address'},
       },
       $defs: {
-        address: addressDef,  // identical content
+        address: addressDef, // identical content
       },
     };
 
@@ -146,7 +146,7 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
         Bar: {
           type: 'object',
           properties: {
-            relatedFoo: {$ref: '#/$defs/Foo'},  // this must become Foo2
+            relatedFoo: {$ref: '#/$defs/Foo'}, // this must become Foo2
           },
         },
       },

--- a/meta_configurator/src/schema/__tests__/extractDefinitions.test.ts
+++ b/meta_configurator/src/schema/__tests__/extractDefinitions.test.ts
@@ -152,7 +152,7 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
       },
     };
 
-    const result = extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
+    extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
 
     // Foo got renamed to Foo2
     expect(rootSchema.data.value.$defs.Foo2).toEqual({type: 'string'});

--- a/meta_configurator/src/schema/__tests__/extractDefinitions.test.ts
+++ b/meta_configurator/src/schema/__tests__/extractDefinitions.test.ts
@@ -105,6 +105,44 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
     expect(result.properties.contact.$ref).toBe('#/$defs/address2');
   });
 
+  it('renames definition if same name already exists at root with different content', () => {
+    // root already has an "address" with different content
+    rootSchema.setDataAt(['$defs', 'address'], {
+      type: 'object',
+      properties: {fullAddress: {type: 'string'}},
+    });
+
+    // AI generates its own "address" with different content
+    const aiResponse = {
+      type: 'object',
+      properties: {
+        contact: {$ref: '#/$defs/address'},
+      },
+      $defs: {
+        address: {
+          type: 'object',
+          properties: {street: {type: 'string'}, city: {type: 'string'}},
+        },
+      },
+    };
+
+    const result = extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
+
+    // should be renamed to address2 to avoid clash
+    expect(rootSchema.data.value.$defs.address2).toEqual({
+      type: 'object',
+      properties: {street: {type: 'string'}, city: {type: 'string'}},
+    });
+
+    // original address untouched
+    expect(rootSchema.data.value.$defs.address).toEqual({
+      type: 'object',
+      properties: {fullAddress: {type: 'string'}},
+    });
+
+    // $ref updated to new name
+    expect(result.properties.contact.$ref).toBe('#/$defs/address2');
+  });
   it('does not duplicate if identical definition already exists at root', () => {
     const addressDef = {
       type: 'object',
@@ -128,6 +166,34 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
 
     // address2 should NOT have been created
     expect(rootSchema.data.value.$defs.address2).toBeUndefined();
+  });
+
+  it('does not duplicate if identical definition already exists at root but under different key', () => {
+    const addressDef = {
+      type: 'object',
+      properties: {street: {type: 'string'}, city: {type: 'string'}},
+    };
+
+    // root already has exact same address content
+    rootSchema.setDataAt(['$defs', 'adresse'], addressDef);
+
+    const aiResponse = {
+      type: 'object',
+      properties: {
+        contact: {$ref: '#/$defs/address'},
+      },
+      $defs: {
+        address: addressDef,  // identical content
+      },
+    };
+
+    extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
+
+    // address should NOT have been created
+    expect(rootSchema.data.value.$defs.address).toBeUndefined();
+
+    // reference should point to existing definition
+    expect(aiResponse.properties.contact.$ref).toBe('#/$defs/adresse');
   });
 
   it('fixes cross references between generated definitions when one gets renamed', () => {
@@ -163,4 +229,6 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
     // original Foo (number) untouched
     expect(rootSchema.data.value.$defs.Foo).toEqual({type: 'number'});
   });
+
+  
 });

--- a/meta_configurator/src/schema/__tests__/extractDefinitions.test.ts
+++ b/meta_configurator/src/schema/__tests__/extractDefinitions.test.ts
@@ -1,0 +1,166 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {shallowRef} from 'vue';
+import {ManagedData} from '@/data/managedData';
+import {SessionMode} from '@/store/sessionMode';
+import {extractGeneratedDefinitionsFromSubSchema} from '@/schema/schemaManipulationUtils';
+
+vi.mock('@/dataformats/formatRegistry', () => ({
+  useDataConverter: () => ({
+    stringify: (data: any) => JSON.stringify(data),
+    parse: (data: string) => JSON.parse(data),
+  }),
+}));
+
+describe('extractGeneratedDefinitionsFromSubSchema', () => {
+  let rootSchema: ManagedData;
+
+  beforeEach(() => {
+    // this is the full schema already in the document
+    // AI does NOT see this — it only sees the sub-element you selected
+    rootSchema = new ManagedData(
+      shallowRef({
+        type: 'object',
+        properties: {
+          owner: {$ref: '#/$defs/owner'},
+        },
+        $defs: {
+          breed: {type: 'string', enum: ['Siamese', 'Persian']},
+          owner: {type: 'object', properties: {name: {type: 'string'}}},
+        },
+      }),
+      SessionMode.SchemaEditor
+    );
+  });
+
+  it('moves $defs from AI sub-schema response up to root', () => {
+    // AI was scoped to owner, returned this — it put address inside owner.$defs
+    const aiResponse = {
+      type: 'object',
+      properties: {
+        name: {type: 'string'},
+        address: {$ref: '#/$defs/address'},
+      },
+      $defs: {
+        address: {
+          type: 'object',
+          properties: {
+            street: {type: 'string'},
+            city: {type: 'string'},
+          },
+        },
+      },
+    };
+
+    const result = extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
+
+    // $defs should be gone from the sub-schema
+    expect(result.$defs).toBeUndefined();
+
+    // address should now be at root level
+    expect(rootSchema.data.value.$defs.address).toEqual({
+      type: 'object',
+      properties: {street: {type: 'string'}, city: {type: 'string'}},
+    });
+
+    // $ref inside the result should still work
+    expect(result.properties.address.$ref).toBe('#/$defs/address');
+  });
+
+  it('renames definition if same name already exists at root with different content', () => {
+    // root already has an "address" with different content
+    rootSchema.setDataAt(['$defs', 'address'], {
+      type: 'object',
+      properties: {fullAddress: {type: 'string'}},
+    });
+
+    // AI generates its own "address" with different content
+    const aiResponse = {
+      type: 'object',
+      properties: {
+        contact: {$ref: '#/$defs/address'},
+      },
+      $defs: {
+        address: {
+          type: 'object',
+          properties: {street: {type: 'string'}, city: {type: 'string'}},
+        },
+      },
+    };
+
+    const result = extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
+
+    // should be renamed to address2 to avoid clash
+    expect(rootSchema.data.value.$defs.address2).toEqual({
+      type: 'object',
+      properties: {street: {type: 'string'}, city: {type: 'string'}},
+    });
+
+    // original address untouched
+    expect(rootSchema.data.value.$defs.address).toEqual({
+      type: 'object',
+      properties: {fullAddress: {type: 'string'}},
+    });
+
+    // $ref updated to new name
+    expect(result.properties.contact.$ref).toBe('#/$defs/address2');
+  });
+
+  it('does not duplicate if identical definition already exists at root', () => {
+    const addressDef = {
+      type: 'object',
+      properties: {street: {type: 'string'}, city: {type: 'string'}},
+    };
+
+    // root already has exact same address content
+    rootSchema.setDataAt(['$defs', 'address'], addressDef);
+
+    const aiResponse = {
+      type: 'object',
+      properties: {
+        contact: {$ref: '#/$defs/address'},
+      },
+      $defs: {
+        address: addressDef,  // identical content
+      },
+    };
+
+    extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
+
+    // address2 should NOT have been created
+    expect(rootSchema.data.value.$defs.address2).toBeUndefined();
+  });
+
+  it('fixes cross references between generated definitions when one gets renamed', () => {
+    // root already has a "Foo" so AI-generated Foo will become Foo2
+    rootSchema.setDataAt(['$defs', 'Foo'], {type: 'number'});
+
+    // AI generated Bar which references Foo — both are new
+    // when Foo becomes Foo2, Bar's internal $ref must also update
+    const aiResponse = {
+      type: 'object',
+      properties: {
+        bar: {$ref: '#/$defs/Bar'},
+      },
+      $defs: {
+        Foo: {type: 'string'},
+        Bar: {
+          type: 'object',
+          properties: {
+            relatedFoo: {$ref: '#/$defs/Foo'},  // this must become Foo2
+          },
+        },
+      },
+    };
+
+    const result = extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
+
+    // Foo got renamed to Foo2
+    expect(rootSchema.data.value.$defs.Foo2).toEqual({type: 'string'});
+
+    // Bar's internal ref must point to Foo2 not Foo
+    expect(rootSchema.data.value.$defs.Bar.properties.relatedFoo.$ref).toBe('#/$defs/Foo2');
+
+    // original Foo (number) untouched
+    expect(rootSchema.data.value.$defs.Foo).toEqual({type: 'number'});
+  });
+});

--- a/meta_configurator/src/schema/__tests__/postProcessSchemaModification.test.ts
+++ b/meta_configurator/src/schema/__tests__/postProcessSchemaModification.test.ts
@@ -2,7 +2,7 @@ import {describe, it, expect, beforeEach, vi} from 'vitest';
 import {shallowRef} from 'vue';
 import {ManagedData} from '@/data/managedData';
 import {SessionMode} from '@/store/sessionMode';
-import {extractGeneratedDefinitionsFromSubSchema} from '@/schema/schemaManipulationUtils';
+import {extractGeneratedDefinitionsFromSubSchema, postProcessSchemaModification} from '@/schema/schemaManipulationUtils';
 
 vi.mock('@/dataformats/formatRegistry', () => ({
   useDataConverter: () => ({
@@ -105,44 +105,6 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
     expect(result.properties.contact.$ref).toBe('#/$defs/address2');
   });
 
-  it('renames definition if same name already exists at root with different content', () => {
-    // root already has an "address" with different content
-    rootSchema.setDataAt(['$defs', 'address'], {
-      type: 'object',
-      properties: {fullAddress: {type: 'string'}},
-    });
-
-    // AI generates its own "address" with different content
-    const aiResponse = {
-      type: 'object',
-      properties: {
-        contact: {$ref: '#/$defs/address'},
-      },
-      $defs: {
-        address: {
-          type: 'object',
-          properties: {street: {type: 'string'}, city: {type: 'string'}},
-        },
-      },
-    };
-
-    const result = extractGeneratedDefinitionsFromSubSchema(aiResponse, rootSchema);
-
-    // should be renamed to address2 to avoid clash
-    expect(rootSchema.data.value.$defs.address2).toEqual({
-      type: 'object',
-      properties: {street: {type: 'string'}, city: {type: 'string'}},
-    });
-
-    // original address untouched
-    expect(rootSchema.data.value.$defs.address).toEqual({
-      type: 'object',
-      properties: {fullAddress: {type: 'string'}},
-    });
-
-    // $ref updated to new name
-    expect(result.properties.contact.$ref).toBe('#/$defs/address2');
-  });
   it('does not duplicate if identical definition already exists at root', () => {
     const addressDef = {
       type: 'object',
@@ -229,10 +191,66 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
     // original Foo (number) untouched
     expect(rootSchema.data.value.$defs.Foo).toEqual({type: 'number'});
   });
-<<<<<<< HEAD
+});
 
-  
+
+describe('postProcessSchemaModification', () => {
+  let rootSchema: ManagedData;
+
+  beforeEach(() => {
+    // this is the full schema already in the document
+    // AI does NOT see this — it only sees the sub-element you selected
+    rootSchema = new ManagedData(
+      shallowRef({
+        type: 'object',
+        properties: {
+          owner: {$ref: '#/$defs/owner'},
+        },
+        $defs: {
+          breed: {type: 'string', enum: ['Siamese', 'Persian']},
+          owner: {type: 'object', properties: {name: {type: 'string'}}},
+        },
+      }),
+      SessionMode.SchemaEditor
+    );
+  });
+
+  it('executes extractGeneratedDefinitionsFromSubSchema and removes $schema property if exists', () => {
+
+    // root already has a "Foo" so AI-generated Foo will become Foo2
+    rootSchema.setDataAt(['$defs', 'Foo'], {type: 'number'});
+
+    // AI generated Bar which references Foo — both are new
+    // when Foo becomes Foo2, Bar's internal $ref must also update
+    const aiResponse = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        bar: {$ref: '#/$defs/Bar'},
+      },
+      $defs: {
+        Foo: {type: 'string'},
+        Bar: {
+          type: 'object',
+          properties: {
+            relatedFoo: {$ref: '#/$defs/Foo'}, // this must become Foo2
+          },
+        },
+      },
+    };
+
+    postProcessSchemaModification(aiResponse, rootSchema);
+
+    // Foo got renamed to Foo2
+    expect(rootSchema.data.value.$defs.Foo2).toEqual({type: 'string'});
+
+    // Bar's internal ref must point to Foo2 not Foo
+    expect(rootSchema.data.value.$defs.Bar.properties.relatedFoo.$ref).toBe('#/$defs/Foo2');
+
+    // original Foo (number) untouched
+    expect(rootSchema.data.value.$defs.Foo).toEqual({type: 'number'});
+
+    // make sure $schema property is removed from the response object
+    expect(aiResponse.$schema).toBeUndefined();
+  });
 });
-=======
-});
->>>>>>> 0d67435d05ab6b72b8c2b1c7ed715e802414f921

--- a/meta_configurator/src/schema/__tests__/postProcessSchemaModification.test.ts
+++ b/meta_configurator/src/schema/__tests__/postProcessSchemaModification.test.ts
@@ -2,7 +2,10 @@ import {describe, it, expect, beforeEach, vi} from 'vitest';
 import {shallowRef} from 'vue';
 import {ManagedData} from '@/data/managedData';
 import {SessionMode} from '@/store/sessionMode';
-import {extractGeneratedDefinitionsFromSubSchema, postProcessSchemaModification} from '@/schema/schemaManipulationUtils';
+import {
+  extractGeneratedDefinitionsFromSubSchema,
+  postProcessSchemaModification,
+} from '@/schema/schemaManipulationUtils';
 
 vi.mock('@/dataformats/formatRegistry', () => ({
   useDataConverter: () => ({
@@ -145,7 +148,7 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
         contact: {$ref: '#/$defs/address'},
       },
       $defs: {
-        address: addressDef,  // identical content
+        address: addressDef, // identical content
       },
     };
 
@@ -193,7 +196,6 @@ describe('extractGeneratedDefinitionsFromSubSchema', () => {
   });
 });
 
-
 describe('postProcessSchemaModification', () => {
   let rootSchema: ManagedData;
 
@@ -216,7 +218,6 @@ describe('postProcessSchemaModification', () => {
   });
 
   it('executes extractGeneratedDefinitionsFromSubSchema and removes $schema property if exists', () => {
-
     // root already has a "Foo" so AI-generated Foo will become Foo2
     rootSchema.setDataAt(['$defs', 'Foo'], {type: 'number'});
 

--- a/meta_configurator/src/schema/schemaManipulationUtils.ts
+++ b/meta_configurator/src/schema/schemaManipulationUtils.ts
@@ -131,11 +131,7 @@ export function createIdentifierForExtractedElement(
 
 export function extractGeneratedDefinitionsFromSubSchema(
   subSchema: any,
-<<<<<<< HEAD
   rootSchemaData: ManagedData
-=======
-  schemaData: ManagedData
->>>>>>> 0d67435d05ab6b72b8c2b1c7ed715e802414f921
 ): any {
   if (subSchema === null || typeof subSchema !== 'object' || Array.isArray(subSchema)) {
     return subSchema;
@@ -170,7 +166,7 @@ export function extractGeneratedDefinitionsFromSubSchema(
   for (const {oldLocalPath, newRootPath} of pathMappings) {
     for (const target of rewriteTargets) {
       updateReferences(oldLocalPath, newRootPath, target, (path, newValue) => {
-        setValueAtPath(target, path, newValue);
+        _.set(target, path, newValue);
       });
     }
   }
@@ -182,15 +178,6 @@ export function extractGeneratedDefinitionsFromSubSchema(
   }
 
   return subSchema;
-}
-
-function setValueAtPath(root: any, path: Path, value: any): void {
-  if (path.length === 0) return;
-  let current = root;
-  for (let i = 0; i < path.length - 1; i++) {
-    current = current[path[i]!];
-  }
-  current[path[path.length - 1]!] = value;
 }
 
 export function addSchemaObject(

--- a/meta_configurator/src/schema/schemaManipulationUtils.ts
+++ b/meta_configurator/src/schema/schemaManipulationUtils.ts
@@ -129,7 +129,10 @@ export function createIdentifierForExtractedElement(
   return identifier;
 }
 
-export function extractGeneratedDefinitionsFromSubSchema(subSchema: any, schemaData: ManagedData): any {
+export function extractGeneratedDefinitionsFromSubSchema(
+  subSchema: any,
+  schemaData: ManagedData
+): any {
   if (subSchema === null || typeof subSchema !== 'object' || Array.isArray(subSchema)) {
     return subSchema;
   }

--- a/meta_configurator/src/schema/schemaManipulationUtils.ts
+++ b/meta_configurator/src/schema/schemaManipulationUtils.ts
@@ -128,7 +128,17 @@ export function createIdentifierForExtractedElement(
   }
   return identifier;
 }
-
+export function postProcessSchemaModification(responseObject: any, schemaData: ManagedData): any {
+  if (responseObject === null || typeof responseObject !== 'object') {
+    return responseObject;
+  }
+  const response = extractGeneratedDefinitionsFromSubSchema(responseObject, schemaData);
+  // if response is a object which contains a $schema property, remove this property, as it is not allowed in sub-schemas
+  if (response && typeof response === 'object' && '$schema' in response) {
+    delete response.$schema;
+  }
+  return response;
+}
 export function extractGeneratedDefinitionsFromSubSchema(
   subSchema: any,
   rootSchemaData: ManagedData

--- a/meta_configurator/src/schema/schemaManipulationUtils.ts
+++ b/meta_configurator/src/schema/schemaManipulationUtils.ts
@@ -129,6 +129,63 @@ export function createIdentifierForExtractedElement(
   return identifier;
 }
 
+export function extractGeneratedDefinitionsFromSubSchema(subSchema: any, schemaData: ManagedData): any {
+  if (subSchema === null || typeof subSchema !== 'object' || Array.isArray(subSchema)) {
+    return subSchema;
+  }
+
+  const localDefinitions: {defsKey: string; name: string; content: any}[] = [];
+  for (const defsKey of ['$defs', 'definitions']) {
+    const localDefs = subSchema[defsKey];
+    if (localDefs === undefined || localDefs === null || typeof localDefs !== 'object') {
+      continue;
+    }
+    delete subSchema[defsKey];
+    for (const definitionName of Object.keys(localDefs)) {
+      localDefinitions.push({defsKey, name: definitionName, content: localDefs[definitionName]});
+    }
+  }
+
+  if (localDefinitions.length === 0) {
+    return subSchema;
+  }
+
+  const pathMappings: {oldLocalPath: Path; newRootPath: Path; content: any}[] = [];
+  for (const {defsKey, name, content} of localDefinitions) {
+    let newRootPath = doesIdenticalSchemaDefinitionExist(schemaData, content);
+    if (newRootPath === undefined) {
+      newRootPath = findAvailableSchemaId(schemaData, ['$defs'], name, true);
+    }
+    pathMappings.push({oldLocalPath: [defsKey, name], newRootPath, content});
+  }
+
+  const rewriteTargets: any[] = [subSchema, ...pathMappings.map(m => m.content)];
+  for (const {oldLocalPath, newRootPath} of pathMappings) {
+    for (const target of rewriteTargets) {
+      updateReferences(oldLocalPath, newRootPath, target, (path, newValue) => {
+        setValueAtPath(target, path, newValue);
+      });
+    }
+  }
+
+  for (const {newRootPath, content} of pathMappings) {
+    if (schemaData.dataAt(newRootPath) === undefined) {
+      schemaData.setDataAt(newRootPath, content);
+    }
+  }
+
+  return subSchema;
+}
+
+function setValueAtPath(root: any, path: Path, value: any): void {
+  if (path.length === 0) return;
+  let current = root;
+  for (let i = 0; i < path.length - 1; i++) {
+    current = current[path[i]!];
+  }
+  current[path[path.length - 1]!] = value;
+}
+
 export function addSchemaObject(
   schemaData: ManagedData,
   connectWithRootIfRootEmpty: boolean = true,

--- a/meta_configurator/src/schema/schemaManipulationUtils.ts
+++ b/meta_configurator/src/schema/schemaManipulationUtils.ts
@@ -129,7 +129,10 @@ export function createIdentifierForExtractedElement(
   return identifier;
 }
 
-export function extractGeneratedDefinitionsFromSubSchema(subSchema: any, schemaData: ManagedData): any {
+export function extractGeneratedDefinitionsFromSubSchema(
+  subSchema: any,
+  rootSchemaData: ManagedData
+): any {
   if (subSchema === null || typeof subSchema !== 'object' || Array.isArray(subSchema)) {
     return subSchema;
   }
@@ -152,11 +155,11 @@ export function extractGeneratedDefinitionsFromSubSchema(subSchema: any, schemaD
 
   const pathMappings: {oldLocalPath: Path; newRootPath: Path; content: any}[] = [];
   for (const {defsKey, name, content} of localDefinitions) {
-    let newRootPath = doesIdenticalSchemaDefinitionExist(schemaData, content);
-    if (newRootPath === undefined) {
-      newRootPath = findAvailableSchemaId(schemaData, ['$defs'], name, true);
+    let newDefinitionPath = doesIdenticalSchemaDefinitionExist(rootSchemaData, content);
+    if (newDefinitionPath === undefined) {
+      newDefinitionPath = findAvailableSchemaId(rootSchemaData, ['$defs'], name, true);
     }
-    pathMappings.push({oldLocalPath: [defsKey, name], newRootPath, content});
+    pathMappings.push({oldLocalPath: [defsKey, name], newRootPath: newDefinitionPath, content});
   }
 
   const rewriteTargets: any[] = [subSchema, ...pathMappings.map(m => m.content)];
@@ -169,8 +172,8 @@ export function extractGeneratedDefinitionsFromSubSchema(subSchema: any, schemaD
   }
 
   for (const {newRootPath, content} of pathMappings) {
-    if (schemaData.dataAt(newRootPath) === undefined) {
-      schemaData.setDataAt(newRootPath, content);
+    if (rootSchemaData.dataAt(newRootPath) === undefined) {
+      rootSchemaData.setDataAt(newRootPath, content);
     }
   }
 


### PR DESCRIPTION
When AI assistance is scoped to a sub-element, the AI only sees that small part of the schema and places any new definitions it creates locally inside that sub-element instead of at the root level where they belong. This fix automatically detects and moves those definitions to the root after the AI responds, handles name clashes by renaming with a numeric suffix, updates all $ref links accordingly.
Automated tests were added to verify the fix works correctly without needing a real AI API call. Tests cover the main scenarios: basic extraction, name clash renaming, duplicate detection, and cross-reference updates between generated definitions.