### PR TITLE
decrease backend relay default rate limits and custom logic for proper backend out of token message to client

### DIFF
--- a/backend/relay/README.md
+++ b/backend/relay/README.md
@@ -74,6 +74,43 @@ with Helmholtz Blablador as the upstream.
 All options are documented in `config.example.yaml`. Copy it to `config.yaml`
 and fill in your provider API keys — everything else has sensible defaults.
 
+### Rate limits
+
+Two independent limits protect the relay, and clients can tell them apart by the
+`type` field of the error response:
+
+| Situation | Status | `type` |
+| --- | --- | --- |
+| The client's IP exceeded the relay's own limits (`rate_limits`) or daily token cap | 429 | `rate_limit_error` / `token_limit_error` |
+| The relay's API key exceeded the provider's limit | 429 | `upstream_rate_limit_error` |
+
+The second case is reported with the relay's own message instead of the
+provider's, since the exhausted quota belongs to the relay and is shared by all
+of its clients: telling that caller they exceeded a rate limit would be wrong.
+It is also logged as a warning (`upstream rate limit reached endpoint=...`),
+which is the signal to raise the quota at the provider or slow clients down.
+
+### Sizing the limits
+
+A public relay shares **one** provider quota between all of its users, so the
+per-IP limits decide how much of it a single client can consume before everyone
+else is locked out. This has happened in production: one user exhausted the
+upstream quota and the relay became unusable for the rest of the day.
+
+Defaults are therefore deliberately tight: 10 requests per minute, 60 per hour
+and 200 per day per IP, plus 50,000 estimated tokens per IP per day.
+
+`max_daily_tokens_per_ip` is the limit that actually protects the quota. A
+request is charged its prompt size (roughly one token per 4 bytes of request
+body) plus its capped `max_tokens`, because the provider bills both and
+MetaConfigurator sends whole documents to the AI. Counting only `max_tokens`
+would let a client send megabyte prompts all day for almost no charge. The
+request counters exist to stop bursts, not to bound cost.
+
+Raise the values only if your provider quota is large or the relay is not public.
+Users who need more throughput should configure their own API key in the AI
+settings instead.
+
 ## Security
 
 - Deploy behind HTTPS — Bearer tokens over plain HTTP are interceptable.

--- a/backend/relay/app.py
+++ b/backend/relay/app.py
@@ -107,15 +107,15 @@ def load_config(path: str) -> RelayConfig:
     rl_raw = raw.get("rate_limits", {})
     rate_limits = RateLimitConfig(
         enabled=rl_raw.get("enabled", True),
-        requests_per_minute=rl_raw.get("requests_per_minute", 20),
-        requests_per_hour=rl_raw.get("requests_per_hour", 200),
-        requests_per_day=rl_raw.get("requests_per_day", 1000),
+        requests_per_minute=rl_raw.get("requests_per_minute", 10),
+        requests_per_hour=rl_raw.get("requests_per_hour", 60),
+        requests_per_day=rl_raw.get("requests_per_day", 200),
     )
 
     lim_raw = raw.get("limits", {})
     limits = LimitsConfig(
         max_request_tokens=lim_raw.get("max_request_tokens", 10000),
-        max_daily_tokens_per_ip=lim_raw.get("max_daily_tokens_per_ip", 100000),
+        max_daily_tokens_per_ip=lim_raw.get("max_daily_tokens_per_ip", 50000),
         max_request_bytes=lim_raw.get("max_request_bytes", 2 * 1024 * 1024),
     )
 
@@ -139,6 +139,19 @@ def load_config(path: str) -> RelayConfig:
         enable_models_proxy=raw.get("enable_models_proxy", True),
         log_level=raw.get("log_level", "INFO").upper(),
     )
+
+
+# Hitting the relay's own per-IP limit and hitting the quota the relay itself has at
+# the provider are different problems for the user, so they get different messages.
+CLIENT_RATE_LIMIT_MESSAGE = (
+    "Too many requests from your IP address to this relay. "
+    "Please wait a moment before trying again."
+)
+UPSTREAM_RATE_LIMIT_MESSAGE = (
+    "This relay has reached its own rate limit at the AI provider it forwards to. "
+    "That quota is shared by everyone using this relay, so it is not caused by your usage. "
+    "Please try again later, or configure your own AI endpoint and API key in the AI settings."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -168,9 +181,23 @@ def find_endpoint(
 
 
 # ---------------------------------------------------------------------------
-# Token tracker (per-IP daily cap, uses max_tokens as estimate)
+# Token tracker (per-IP daily cap, estimated from prompt size and max_tokens)
 # No library covers this use-case; kept as a lightweight custom class.
 # ---------------------------------------------------------------------------
+
+# Rough characters-per-token ratio, good enough to bound usage across models.
+CHARACTERS_PER_TOKEN = 4
+
+
+def estimate_prompt_tokens(request_bytes: int) -> int:
+    """Estimate the prompt tokens a request body will cost upstream.
+
+    The provider charges for the prompt as well, and MetaConfigurator sends whole
+    documents (imports, mappings, schemas), so the prompt usually dominates the
+    cost. Counting only max_tokens would let one client send megabyte prompts all
+    day while barely touching the daily cap.
+    """
+    return request_bytes // CHARACTERS_PER_TOKEN
 
 
 class TokenTracker:
@@ -180,8 +207,13 @@ class TokenTracker:
         # ip -> list of (unix_timestamp, tokens_used)
         self._usage: dict[str, list[tuple[float, int]]] = {}
 
-    def check_and_track(self, ip: str, requested_tokens: int) -> tuple[int, bool]:
+    def check_and_track(
+        self, ip: str, requested_tokens: int, prompt_tokens: int = 0
+    ) -> tuple[int, bool]:
         """Cap requested_tokens to max_request_tokens, check daily limit.
+
+        The daily limit is charged *prompt_tokens* plus the capped completion
+        tokens, since the provider bills both.
 
         Returns (capped_tokens, allowed).
         Set max_daily_tokens_per_ip to 0 in config to disable daily tracking.
@@ -190,14 +222,15 @@ class TokenTracker:
         # 0 means "no daily token limit"
         if self._cfg.max_daily_tokens_per_ip <= 0:
             return capped, True
+        charged = capped + prompt_tokens
         now = self._now()
         cutoff = now - 86400
         entries = self._usage.setdefault(ip, [])
         self._usage[ip] = [(ts, tok) for ts, tok in entries if ts >= cutoff]
         used_today = sum(tok for _, tok in self._usage[ip])
-        if used_today + capped > self._cfg.max_daily_tokens_per_ip:
+        if used_today + charged > self._cfg.max_daily_tokens_per_ip:
             return capped, False
-        self._usage[ip].append((now, capped))
+        self._usage[ip].append((now, charged))
         return capped, True
 
 
@@ -259,7 +292,7 @@ def create_app(config: RelayConfig) -> Flask:
 
     @app.errorhandler(429)
     def _rate_limit_error(e):
-        return jsonify({"error": {"message": "Rate limit exceeded", "type": "rate_limit_error"}}), 429
+        return jsonify({"error": {"message": CLIENT_RATE_LIMIT_MESSAGE, "type": "rate_limit_error"}}), 429
 
     # -----------------------------------------------------------------------
     # Helpers
@@ -290,6 +323,16 @@ def create_app(config: RelayConfig) -> Flask:
         if parsed < 0:
             return None, _error("max_tokens must be non-negative", "relay_error", 400)[0]
         return parsed, None
+
+    def _upstream_rate_limited(ep: EndpointConfig, path: str) -> tuple[Response, int]:
+        """Report an upstream 429 as the relay's own exhausted quota.
+
+        Passing the provider's message through instead would tell the caller they
+        exceeded a rate limit they never used: the quota belongs to the relay's API
+        key and is shared by every client of this relay.
+        """
+        log.warning("upstream rate limit reached endpoint=%s path=%s", ep.name, path)
+        return _error(UPSTREAM_RATE_LIMIT_MESSAGE, "upstream_rate_limit_error", 429)
 
     def _upstream_headers(ep: EndpointConfig) -> dict[str, str]:
         prefix = ep.auth_prefix
@@ -347,6 +390,8 @@ def create_app(config: RelayConfig) -> Flask:
         try:
             resp = requests.get(url, headers=_upstream_headers(ep), timeout=config.request_timeout)
             _log("GET", "/v1/models", resp.status_code, time.monotonic() - start)
+            if resp.status_code == 429:
+                return _upstream_rate_limited(ep, "/v1/models")
             return Response(
                 resp.content,
                 status=resp.status_code,
@@ -407,9 +452,18 @@ def create_app(config: RelayConfig) -> Flask:
         raw_max_tokens, token_parse_err = _parse_max_tokens(parsed.get("max_tokens"))
         if token_parse_err:
             return token_parse_err, 400
-        capped_tokens, token_ok = token_tracker.check_and_track(ip, raw_max_tokens)
+        capped_tokens, token_ok = token_tracker.check_and_track(
+            ip, raw_max_tokens, estimate_prompt_tokens(len(body))
+        )
         if not token_ok:
-            return _error("Daily token limit exceeded for your IP", "token_limit_error", 429)
+            return _error(
+                "Daily token limit exceeded for your IP address. This relay shares one "
+                "provider quota between all of its users, so each address gets a fixed "
+                "share per day. Please try again tomorrow, or configure your own AI "
+                "endpoint and API key in the AI settings.",
+                "token_limit_error",
+                429,
+            )
         if capped_tokens != raw_max_tokens:
             parsed["max_tokens"] = capped_tokens
             body = json.dumps(parsed).encode()
@@ -433,6 +487,11 @@ def create_app(config: RelayConfig) -> Flask:
         except requests.RequestException:
             _log("POST", upstream_path, 502, time.monotonic() - start, model)
             return _error("Upstream request failed", "relay_error", 502)
+
+        if upstream_resp.status_code == 429:
+            upstream_resp.close()
+            _log("POST", upstream_path, 429, time.monotonic() - start, model)
+            return _upstream_rate_limited(ep, upstream_path)
 
         if is_stream:
             content_type = upstream_resp.headers.get("Content-Type", "text/event-stream")

--- a/backend/relay/config.example.yaml
+++ b/backend/relay/config.example.yaml
@@ -27,11 +27,15 @@ allowed_origins:
 # Rate limiting (per client IP)
 # ---------------------------------------------------------------------------
 
+# A public relay shares ONE provider quota between all of its users, so these
+# limits decide how much of that shared quota a single client may consume before
+# everyone else is locked out. Keep them tight: allow comfortable interactive use,
+# not bulk processing. Users who need more should configure their own API key.
 rate_limits:
   enabled: true
-  requests_per_minute: 20
-  requests_per_hour: 200
-  requests_per_day: 1000
+  requests_per_minute: 10
+  requests_per_hour: 60
+  requests_per_day: 200
 
 # ---------------------------------------------------------------------------
 # Usage limits
@@ -41,7 +45,11 @@ limits:
   # Caps the max_tokens value per request (prevents runaway token use).
   max_request_tokens: 10000
   # Max tokens a single IP may use in 24 h. Set to 0 to disable.
-  max_daily_tokens_per_ip: 100000
+  # A request is charged its prompt size (about one token per 4 bytes of body)
+  # plus its capped max_tokens, because the provider bills both and
+  # MetaConfigurator sends whole documents. This is the limit that actually
+  # protects the shared quota; the request counters above only stop bursts.
+  max_daily_tokens_per_ip: 50000
   # Max request body size in bytes.
   max_request_bytes: 2097152
 

--- a/backend/relay/tests/test_relay.py
+++ b/backend/relay/tests/test_relay.py
@@ -11,11 +11,14 @@ from typing import Any
 import responses as rsps_lib
 
 from app import (
+    CLIENT_RATE_LIMIT_MESSAGE,
+    UPSTREAM_RATE_LIMIT_MESSAGE,
     EndpointConfig,
     LimitsConfig,
     RateLimitConfig,
     RelayConfig,
     create_app,
+    estimate_prompt_tokens,
     find_endpoint,
 )
 
@@ -193,6 +196,41 @@ def test_upstream_api_key_injected_not_client_key():
 
 
 @rsps_lib.activate
+def test_upstream_rate_limit_is_reported_as_the_relays_own_quota():
+    rsps_lib.add(
+        rsps_lib.POST,
+        f"{UPSTREAM}/chat/completions",
+        json={"error": {"message": "You exceeded your current quota", "type": "rate_limit_error"}},
+        status=429,
+    )
+
+    app = create_app(make_config())
+    with app.test_client() as client:
+        resp = _post_json(client, "/v1/chat/completions", {"model": "gpt-4o", "messages": []})
+
+    assert resp.status_code == 429
+    error = resp.get_json()["error"]
+    assert error["type"] == "upstream_rate_limit_error"
+    # the caller must not be told that they exceeded a limit they never used
+    assert error["message"] == UPSTREAM_RATE_LIMIT_MESSAGE
+    assert "You exceeded your current quota" not in error["message"]
+
+
+@rsps_lib.activate
+def test_streamed_upstream_rate_limit_is_reported_as_the_relays_own_quota():
+    rsps_lib.add(rsps_lib.POST, f"{UPSTREAM}/chat/completions", body="rate limited", status=429)
+
+    app = create_app(make_config())
+    with app.test_client() as client:
+        resp = _post_json(
+            client, "/v1/chat/completions", {"model": "gpt-4o", "messages": [], "stream": True}
+        )
+
+    assert resp.status_code == 429
+    assert resp.get_json()["error"]["type"] == "upstream_rate_limit_error"
+
+
+@rsps_lib.activate
 def test_upstream_error_passed_through():
     rsps_lib.add(rsps_lib.POST, f"{UPSTREAM}/chat/completions", json={"error": "bad key"}, status=401)
 
@@ -340,7 +378,9 @@ def test_rate_limit_error_has_correct_type():
         resp = _post_json(client, "/v1/chat/completions", {"model": "gpt-4o", "messages": []})
 
     assert resp.status_code == 429
-    assert resp.get_json()["error"]["type"] == "rate_limit_error"
+    error = resp.get_json()["error"]
+    assert error["type"] == "rate_limit_error"
+    assert error["message"] == CLIENT_RATE_LIMIT_MESSAGE
 
 
 def test_health_is_exempt_from_rate_limiting():
@@ -393,6 +433,37 @@ def test_max_tokens_within_limit_unchanged():
         _post_json(client, "/v1/chat/completions", {"model": "gpt-4o", "messages": [], "max_tokens": 500})
 
     assert captured_body[0]["max_tokens"] == 500
+
+
+@rsps_lib.activate
+def test_large_prompt_counts_towards_the_daily_token_limit():
+    """A big prompt with a small max_tokens must not slip past the daily cap."""
+    for _ in range(3):
+        rsps_lib.add(rsps_lib.POST, f"{UPSTREAM}/chat/completions", json={"choices": []}, status=200)
+
+    # 40000 characters of prompt ~ 10000 tokens, so the second request exceeds the cap
+    limits = LimitsConfig(
+        max_request_tokens=10000, max_daily_tokens_per_ip=15000, max_request_bytes=2 * 1024 * 1024
+    )
+    app = create_app(make_config(limits=limits))
+
+    body = {
+        "model": "gpt-4o",
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "x" * 40000}],
+    }
+    with app.test_client() as client:
+        first = _post_json(client, "/v1/chat/completions", body)
+        second = _post_json(client, "/v1/chat/completions", body)
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.get_json()["error"]["type"] == "token_limit_error"
+
+
+def test_prompt_token_estimate_scales_with_request_size():
+    assert estimate_prompt_tokens(0) == 0
+    assert estimate_prompt_tokens(4000) == 1000
 
 
 def test_oversized_body_returns_413():

--- a/meta_configurator/src/utility/ai/aiRequestError.ts
+++ b/meta_configurator/src/utility/ai/aiRequestError.ts
@@ -5,6 +5,7 @@ export function throwAiRequestError(
   backend: AiBackendCorsEndpoint | AiBackendRelay
 ): never {
   const status: number | undefined = error?.response?.status;
+  const errorType: string | undefined = error?.response?.data?.error?.type;
   const machineMessage: string =
     error?.response?.data?.error?.message ?? error?.message ?? String(error);
 
@@ -34,6 +35,16 @@ export function throwAiRequestError(
     return raise(
       'The request was rejected by the API (400 Bad Request). A model parameter is likely wrong or not supported by the selected model. ' +
         'For example, some models use "max_completion_tokens" instead of "max_tokens". Check your custom model parameters in the AI settings.'
+    );
+  }
+
+  // A relay forwards to the provider with its own API key, so a rate limit hit there
+  // is not the user's: saying otherwise confuses users who have not used the relay yet.
+  if (status === 429 && errorType === 'upstream_rate_limit_error') {
+    return raise(
+      'The relay has reached its own rate limit at the AI provider (429 Too Many Requests). ' +
+        'That quota is shared by everyone using the relay, so this is not caused by your own usage. ' +
+        'Please try again later, or configure your own endpoint and API key in the AI settings.'
     );
   }
 


### PR DESCRIPTION
**What was done:**

decrease backend relay default rate limits and custom logic for proper backend out of token message to client

**Why:**

For public relay the rate limit was reached by a single user, blocking requests for all other users too. Also other users got a wrong error message, making it seem as if they had reached the rate limit personally.

