### PR TITLE
fix settings sync bug

### DIFF
--- a/meta_configurator/e2e/panelToggle.spec.ts
+++ b/meta_configurator/e2e/panelToggle.spec.ts
@@ -1,0 +1,62 @@
+import {expect, test, type Page} from '@playwright/test';
+import {forceEditorMode, openApp} from '../../tests/shared/utils';
+import {SessionMode} from '../src/store/sessionMode';
+
+function panelToggleButton(page: Page, icon: string) {
+  return page
+    .locator('.toolbar-top .toolbar-menu-buttons')
+    .locator('button')
+    .filter({has: page.locator(`svg[data-icon="${icon}"]`)});
+}
+
+test.beforeEach(async ({page}) => {
+  await openApp(page);
+});
+
+test('an open view can be closed and reopened from the menu bar', async ({page}) => {
+  const panels = page.locator('#mainpanel .p-splitterpanel');
+  const textViewButton = panelToggleButton(page, 'code');
+
+  await expect(panels).toHaveCount(2);
+  await expect(textViewButton).toHaveClass(/highlighted-icon/);
+
+  await textViewButton.click();
+
+  await expect(panels).toHaveCount(1);
+  await expect(textViewButton).not.toHaveClass(/highlighted-icon/);
+
+  await textViewButton.click();
+
+  await expect(panels).toHaveCount(2);
+  await expect(textViewButton).toHaveClass(/highlighted-icon/);
+});
+
+test('a closed view can be opened and closed from the menu bar', async ({page}) => {
+  const panels = page.locator('#mainpanel .p-splitterpanel');
+  const tableViewButton = panelToggleButton(page, 'table');
+
+  await expect(panels).toHaveCount(2);
+  await expect(tableViewButton).not.toHaveClass(/highlighted-icon/);
+
+  await tableViewButton.click();
+
+  await expect(panels).toHaveCount(3);
+  await expect(tableViewButton).toHaveClass(/highlighted-icon/);
+
+  await tableViewButton.click();
+
+  await expect(panels).toHaveCount(2);
+  await expect(tableViewButton).not.toHaveClass(/highlighted-icon/);
+});
+
+test('the panel layout follows a full settings replacement', async ({page}) => {
+  await openApp(page, 'settings_testpanel.json');
+  await forceEditorMode(page, SessionMode.Settings);
+
+  const panels = page.locator('#mainpanel .p-splitterpanel');
+  await expect(panels).toHaveCount(3);
+
+  await page.locator('#settings_restore').click();
+
+  await expect(panels).toHaveCount(2);
+});

--- a/meta_configurator/src/components/CombinedEditorComponent.vue
+++ b/meta_configurator/src/components/CombinedEditorComponent.vue
@@ -3,7 +3,7 @@ Main component of the application.
 Combines the code editor and the gui editor.
 -->
 <script lang="ts" setup>
-import {computed, onMounted, onUnmounted, ref, watch} from 'vue';
+import {computed, onMounted, onUnmounted, ref, shallowRef, watch} from 'vue';
 import 'primeicons/primeicons.css';
 import SplitterPanel from 'primevue/splitterpanel';
 import Splitter from 'primevue/splitter';
@@ -32,17 +32,21 @@ const props = defineProps<{
 
 const settings = useSettings();
 const settingsData = getDataForMode(SessionMode.Settings);
-let panelsDefinition: SettingsInterfacePanels = settings.value.panels;
+// Keep an isolated snapshot: nested writes happen before a shallow-ref notification, so sharing
+// settings.value.panels here would make old and new definitions indistinguishable in the watcher.
+const panelsDefinition = shallowRef<SettingsInterfacePanels>(
+  structuredClone(settings.value.panels)
+);
 
 // update panelsDefinition only when underlying data changes. Otherwise, all panels will be rebuilt every time
 // any setting is changed, which is not necessary and leads to Ace Editor becoming blank if settings were modified via
 // Ace Editor
 watchImmediate(
-  () => settings,
-  settings => {
-    const panels = settings.value.panels;
-    if (JSON.stringify(panels) !== JSON.stringify(panelsDefinition)) {
-      panelsDefinition = panels;
+  settings,
+  currentSettings => {
+    const panels = currentSettings.panels;
+    if (JSON.stringify(panels) !== JSON.stringify(panelsDefinition.value)) {
+      panelsDefinition.value = structuredClone(panels);
     }
     // fix panels if they are not defined
     for (let mode of Object.values(SessionMode)) {
@@ -59,7 +63,7 @@ watchImmediate(
 );
 
 const panels = computed(() => {
-  return panelsDefinition[props.sessionMode].map(panel => {
+  return panelsDefinition.value[props.sessionMode].map(panel => {
     return {
       component: panelTypeRegistry.getPanelTypeDefinition(panel.panelType).getComponent(),
       sessionMode: panel.mode,

--- a/meta_configurator/src/components/CombinedEditorComponent.vue
+++ b/meta_configurator/src/components/CombinedEditorComponent.vue
@@ -41,26 +41,21 @@ const panelsDefinition = shallowRef<SettingsInterfacePanels>(
 // update panelsDefinition only when underlying data changes. Otherwise, all panels will be rebuilt every time
 // any setting is changed, which is not necessary and leads to Ace Editor becoming blank if settings were modified via
 // Ace Editor
-watchImmediate(
-  settings,
-  currentSettings => {
-    const panels = currentSettings.panels;
-    if (JSON.stringify(panels) !== JSON.stringify(panelsDefinition.value)) {
-      panelsDefinition.value = structuredClone(panels);
-    }
-    // fix panels if they are not defined
-    for (let mode of Object.values(SessionMode)) {
-      if (!panels[mode]) {
-        settingsData.setDataAt(
-          ['panels', mode],
-          structuredClone(
-            SETTINGS_DATA_DEFAULT.panels[mode]
-          ) as SettingsInterfacePanels[typeof mode]
-        );
-      }
+watchImmediate(settings, currentSettings => {
+  const panels = currentSettings.panels;
+  if (JSON.stringify(panels) !== JSON.stringify(panelsDefinition.value)) {
+    panelsDefinition.value = structuredClone(panels);
+  }
+  // fix panels if they are not defined
+  for (let mode of Object.values(SessionMode)) {
+    if (!panels[mode]) {
+      settingsData.setDataAt(
+        ['panels', mode],
+        structuredClone(SETTINGS_DATA_DEFAULT.panels[mode]) as SettingsInterfacePanels[typeof mode]
+      );
     }
   }
-);
+});
 
 const panels = computed(() => {
   return panelsDefinition.value[props.sessionMode].map(panel => {

--- a/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
+++ b/meta_configurator/src/components/panels/ai-prompts/AiPromptsTemplate.vue
@@ -110,7 +110,7 @@ const exportedDocument: Ref<string> = ref('');
 
 const {editorElementId: correctedDocumentEditorId, createEditor: createCorrectedDocumentEditor} =
   useAceEditor('ai-prompts', newDocument, {
-    configureEditor: editor => setupAceMode(editor, settings.value),
+    configureEditor: editor => setupAceMode(editor, settings),
   });
 const {editorElementId: exportedDocumentEditorId, createEditor: createExportedDocumentEditor} =
   useAceEditor('ai-prompts-export', exportedDocument, {});

--- a/meta_configurator/src/components/panels/code-editor/AceEditor.vue
+++ b/meta_configurator/src/components/panels/code-editor/AceEditor.vue
@@ -48,8 +48,8 @@ onMounted(() => {
   editor.value.setOption('wrap', true);
   editor.value.setOption('hScrollBarAlwaysVisible', false);
 
-  disposeAceMode = setupAceMode(editor.value, settings.value);
-  disposeAceProperties = setupAceProperties(editor.value, settings.value);
+  disposeAceMode = setupAceMode(editor.value, settings);
+  disposeAceProperties = setupAceProperties(editor.value, settings);
   connectAceUndoManagerToGlobalUndo(editor.value, getDataForMode(props.sessionMode).undoManager);
 
   setupLinkToData(editor.value, props.sessionMode);

--- a/meta_configurator/src/components/panels/shared-components/__tests__/aceUtils.test.ts
+++ b/meta_configurator/src/components/panels/shared-components/__tests__/aceUtils.test.ts
@@ -31,9 +31,7 @@ describe('Ace settings reactivity', () => {
 
   it('updates the editor when nested settings in the shallow store change', async () => {
     vi.useFakeTimers();
-    const settings = shallowRef(
-      structuredClone(SETTINGS_DATA_DEFAULT) as SettingsInterfaceRoot
-    );
+    const settings = shallowRef(structuredClone(SETTINGS_DATA_DEFAULT) as SettingsInterfaceRoot);
     const settingsData = new ManagedData(settings, SessionMode.Settings);
     const {editor, session} = editorDouble();
 

--- a/meta_configurator/src/components/panels/shared-components/__tests__/aceUtils.test.ts
+++ b/meta_configurator/src/components/panels/shared-components/__tests__/aceUtils.test.ts
@@ -1,0 +1,60 @@
+import {nextTick, shallowRef} from 'vue';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {setupAceMode, setupAceProperties} from '../aceUtils';
+import {SETTINGS_DATA_DEFAULT} from '@/settings/defaultSettingsData';
+import type {SettingsInterfaceRoot} from '@/settings/settingsTypes';
+import type {Editor} from 'brace';
+import {ManagedData} from '@/data/managedData';
+import {SessionMode} from '@/store/sessionMode';
+
+function editorDouble() {
+  const session = {
+    setMode: vi.fn(),
+    setTabSize: vi.fn(),
+  };
+  const editor = {
+    $blockScrolling: 0,
+    getSession: () => session,
+    setOptions: vi.fn(),
+    setShowPrintMargin: vi.fn(),
+    setTheme: vi.fn(),
+    setFontSize: vi.fn(),
+  } as unknown as Editor;
+
+  return {editor, session};
+}
+
+describe('Ace settings reactivity', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('updates the editor when nested settings in the shallow store change', async () => {
+    vi.useFakeTimers();
+    const settings = shallowRef(
+      structuredClone(SETTINGS_DATA_DEFAULT) as SettingsInterfaceRoot
+    );
+    const settingsData = new ManagedData(settings, SessionMode.Settings);
+    const {editor, session} = editorDouble();
+
+    const stopMode = setupAceMode(editor, settings);
+    const stopProperties = setupAceProperties(editor, settings);
+    vi.runAllTimers();
+
+    expect(session.setMode).toHaveBeenLastCalledWith('ace/mode/json');
+    expect(session.setTabSize).toHaveBeenLastCalledWith(2);
+    expect(editor.setFontSize).toHaveBeenLastCalledWith('14px');
+
+    settingsData.setDataAt(['dataFormat'], 'yaml');
+    settingsData.setDataAt(['textEditor', 'tabSize'], 4);
+    settingsData.setDataAt(['textEditor', 'fontSize'], 18);
+    await nextTick();
+
+    expect(session.setMode).toHaveBeenLastCalledWith('ace/mode/yaml');
+    expect(session.setTabSize).toHaveBeenLastCalledWith(4);
+    expect(editor.setFontSize).toHaveBeenLastCalledWith('18px');
+
+    stopMode();
+    stopProperties();
+  });
+});

--- a/meta_configurator/src/components/panels/shared-components/aceUtils.ts
+++ b/meta_configurator/src/components/panels/shared-components/aceUtils.ts
@@ -3,15 +3,18 @@ import {watchImmediate} from '@vueuse/core';
 import type {SettingsInterfaceRoot} from '@/settings/settingsTypes';
 import {isDarkMode} from '@/utility/darkModeUtils';
 import type {UndoManager} from '@/data/undoManager';
-import type {WatchStopHandle} from 'vue';
+import type {Ref, WatchStopHandle} from 'vue';
 
 /**
  * change the mode depending on the data format.
  * to support new data formats, they need to be added here too.
  */
-export function setupAceMode(editor: Editor, settings: SettingsInterfaceRoot): WatchStopHandle {
+export function setupAceMode(
+  editor: Editor,
+  settings: Ref<SettingsInterfaceRoot>
+): WatchStopHandle {
   return watchImmediate(
-    () => settings.dataFormat,
+    () => settings.value.dataFormat,
     format => {
       if (format == 'json') {
         editor.getSession().setMode('ace/mode/json');
@@ -24,7 +27,10 @@ export function setupAceMode(editor: Editor, settings: SettingsInterfaceRoot): W
   );
 }
 
-export function setupAceProperties(editor: Editor, settings: SettingsInterfaceRoot): () => void {
+export function setupAceProperties(
+  editor: Editor,
+  settings: Ref<SettingsInterfaceRoot>
+): () => void {
   editor.$blockScrolling = Infinity;
   editor.setOptions({
     autoScrollEditorIntoView: true, // this is needed if editor is inside scrollable page
@@ -35,7 +41,7 @@ export function setupAceProperties(editor: Editor, settings: SettingsInterfaceRo
     editor.setTheme(darkModeEnabled ? 'ace/theme/clouds_midnight' : 'ace/theme/clouds');
   });
   const stopWatchingTabSize = watchImmediate(
-    () => settings.textEditor.tabSize,
+    () => settings.value.textEditor.tabSize,
     tabSize => editor.getSession().setTabSize(tabSize)
   );
 
@@ -44,7 +50,7 @@ export function setupAceProperties(editor: Editor, settings: SettingsInterfaceRo
   let stopWatchingFontSize: WatchStopHandle | undefined;
   const fontSizeWatcherTimeout = window.setTimeout(() => {
     stopWatchingFontSize = watchImmediate(
-      () => settings.textEditor.fontSize,
+      () => settings.value.textEditor.fontSize,
       fontSize => {
         if (fontSize && fontSize > 6 && fontSize < 65) {
           editor.setFontSize(`${fontSize}px`);

--- a/meta_configurator/src/components/panels/shared-components/useAceEditor.ts
+++ b/meta_configurator/src/components/panels/shared-components/useAceEditor.ts
@@ -52,7 +52,7 @@ export function useAceEditor(
     const createdEditor = ace.edit(editorElementId);
     editor.value = createdEditor;
 
-    const disposeAceProperties = setupAceProperties(createdEditor, settings.value);
+    const disposeAceProperties = setupAceProperties(createdEditor, settings);
     const disposeCallerConfiguration = setup.configureEditor?.(createdEditor);
     disposeEditorConfiguration = () => {
       disposeCallerConfiguration?.();

--- a/meta_configurator/src/components/toolbar/Toolbar.vue
+++ b/meta_configurator/src/components/toolbar/Toolbar.vue
@@ -29,6 +29,7 @@ import ImportSchemaDialog from '@/components/toolbar/dialogs/schema-conversion/I
 import ExportSchemaDialog from '@/components/toolbar/dialogs/schema-conversion/ExportSchemaDialog.vue';
 import InferSchemaDialog from '@/components/toolbar/dialogs/schema-infer/InferSchemaDialog.vue';
 import type {SchemaOption} from '@/packaged-schemas/schemaOption';
+import {getDataForMode} from '@/data/useDataLink';
 
 defineOptions({name: 'MainToolbar'});
 
@@ -199,8 +200,7 @@ defineExpose({
           showSchemaSelectionDialog();
 
           if (dontShowAgain) {
-            const settings = useSettings().value;
-            setCurrentNewsHash(settings);
+            setCurrentNewsHash(getDataForMode(SessionMode.Settings));
           }
         }
       }

--- a/meta_configurator/src/components/toolbar/__tests__/currentNews.test.ts
+++ b/meta_configurator/src/components/toolbar/__tests__/currentNews.test.ts
@@ -7,9 +7,7 @@ import {SessionMode} from '@/store/sessionMode';
 import {setCurrentNewsHash} from '../currentNews';
 
 it('notifies the shallow settings store when the current news is dismissed permanently', async () => {
-  const settings = shallowRef(
-    structuredClone(SETTINGS_DATA_DEFAULT) as SettingsInterfaceRoot
-  );
+  const settings = shallowRef(structuredClone(SETTINGS_DATA_DEFAULT) as SettingsInterfaceRoot);
   const settingsData = new ManagedData(settings, SessionMode.Settings);
   const settingsWatcher = vi.fn();
   watch(settings, settingsWatcher);

--- a/meta_configurator/src/components/toolbar/__tests__/currentNews.test.ts
+++ b/meta_configurator/src/components/toolbar/__tests__/currentNews.test.ts
@@ -1,0 +1,22 @@
+import {nextTick, shallowRef, watch} from 'vue';
+import {expect, it, vi} from 'vitest';
+import {ManagedData} from '@/data/managedData';
+import {SETTINGS_DATA_DEFAULT} from '@/settings/defaultSettingsData';
+import type {SettingsInterfaceRoot} from '@/settings/settingsTypes';
+import {SessionMode} from '@/store/sessionMode';
+import {setCurrentNewsHash} from '../currentNews';
+
+it('notifies the shallow settings store when the current news is dismissed permanently', async () => {
+  const settings = shallowRef(
+    structuredClone(SETTINGS_DATA_DEFAULT) as SettingsInterfaceRoot
+  );
+  const settingsData = new ManagedData(settings, SessionMode.Settings);
+  const settingsWatcher = vi.fn();
+  watch(settings, settingsWatcher);
+
+  setCurrentNewsHash(settingsData);
+  await nextTick();
+
+  expect(settings.value.latestNewsHash).not.toBe(SETTINGS_DATA_DEFAULT.latestNewsHash);
+  expect(settingsWatcher).toHaveBeenCalledOnce();
+});

--- a/meta_configurator/src/components/toolbar/__tests__/menuItems.test.ts
+++ b/meta_configurator/src/components/toolbar/__tests__/menuItems.test.ts
@@ -23,8 +23,15 @@ import {SETTINGS_DATA_DEFAULT} from '@/settings/defaultSettingsData';
 import type {SettingsInterfaceRoot} from '@/settings/settingsTypes';
 
 // the editor content the mocked data link serves to the menu entries
-const editorData = (useDataLink as unknown as {editorData: Record<string, {value: unknown}>})
-  .editorData;
+const editorData = (
+  useDataLink as unknown as {
+    editorData: {
+      dataEditor: {value: unknown};
+      schemaEditor: {value: unknown};
+      settings: {value: unknown};
+    };
+  }
+).editorData;
 
 // the menu entries only reference the dialog actions, they are never invoked here
 const menuItems = new MenuItems({} as MenuItemDialogActions);

--- a/meta_configurator/src/components/toolbar/currentNews.ts
+++ b/meta_configurator/src/components/toolbar/currentNews.ts
@@ -1,4 +1,4 @@
-import type {SettingsInterfaceRoot} from '@/settings/settingsTypes';
+import type {ManagedData} from '@/data/managedData';
 
 export const CURRENT_NEWS_HEADER = 'Get in touch with us.';
 
@@ -16,8 +16,8 @@ export function hasCurrentNewsChanged(latestSeenNewsHash: number): boolean {
   return latestSeenNewsHash !== getCurrentNewsHash() && latestSeenNewsHash !== -1;
 }
 
-export function setCurrentNewsHash(settings: SettingsInterfaceRoot) {
-  settings.latestNewsHash = getCurrentNewsHash();
+export function setCurrentNewsHash(settingsData: ManagedData) {
+  settingsData.setDataAt(['latestNewsHash'], getCurrentNewsHash());
 }
 
 function simpleHash(str: string): number {

--- a/meta_configurator/src/components/toolbar/menuItems.ts
+++ b/meta_configurator/src/components/toolbar/menuItems.ts
@@ -330,17 +330,21 @@ export class MenuItems {
           settings.metaSchema.allowMultipleTypes &&
           !settings.metaSchema.markMoreFieldsAsAdvanced,
         () => {
-          const metaSchema = settings.metaSchema;
-          metaSchema.allowBooleanSchema = true;
-          metaSchema.allowMultipleTypes = true;
-          metaSchema.markMoreFieldsAsAdvanced = false;
+          getDataForMode(SessionMode.Settings).updateData(currentSettings => {
+            const metaSchema = currentSettings.metaSchema;
+            metaSchema.allowBooleanSchema = true;
+            metaSchema.allowMultipleTypes = true;
+            metaSchema.markMoreFieldsAsAdvanced = false;
+          });
         },
         () => {
-          const metaSchema = settings.metaSchema;
-          metaSchema.allowBooleanSchema = false;
-          metaSchema.allowMultipleTypes = false;
-          metaSchema.markMoreFieldsAsAdvanced = true;
-          metaSchema.objectTypesComfort = true;
+          getDataForMode(SessionMode.Settings).updateData(currentSettings => {
+            const metaSchema = currentSettings.metaSchema;
+            metaSchema.allowBooleanSchema = false;
+            metaSchema.allowMultipleTypes = false;
+            metaSchema.markMoreFieldsAsAdvanced = true;
+            metaSchema.objectTypesComfort = true;
+          });
         },
         'fa-solid fa-lock',
         'fa-solid fa-lock-open',
@@ -354,12 +358,16 @@ export class MenuItems {
       this.generateToggleButton(
         () => settings.metaSchema.showJsonLdFields,
         () => {
-          const metaSchema = settings.metaSchema;
-          metaSchema.showJsonLdFields = true;
+          getDataForMode(SessionMode.Settings).setDataAt(
+            ['metaSchema', 'showJsonLdFields'],
+            true
+          );
         },
         () => {
-          const metaSchema = settings.metaSchema;
-          metaSchema.showJsonLdFields = false;
+          getDataForMode(SessionMode.Settings).setDataAt(
+            ['metaSchema', 'showJsonLdFields'],
+            false
+          );
         },
         'fa-solid fa-circle-nodes',
         'fa-solid fa-circle-nodes',
@@ -464,17 +472,21 @@ export class MenuItems {
           panel => panel.panelType === panelTypeName && panel.mode === mode
         ) !== undefined,
       () => {
-        const panels = settings.panels;
-        panels[mode].push({
-          panelType: panelTypeName,
-          mode,
-          size: 40,
-        });
+        getDataForMode(SessionMode.Settings).setDataAt(['panels', mode], [
+          ...settings.panels[mode],
+          {
+            panelType: panelTypeName,
+            mode,
+            size: 40,
+          },
+        ]);
       },
       () => {
-        const panels = settings.panels;
-        panels[mode] = panels[mode].filter(
-          panel => !(panel.panelType === panelTypeName && panel.mode === mode)
+        getDataForMode(SessionMode.Settings).setDataAt(
+          ['panels', mode],
+          settings.panels[mode].filter(
+            panel => !(panel.panelType === panelTypeName && panel.mode === mode)
+          )
         );
       },
       iconName,

--- a/meta_configurator/src/components/toolbar/menuItems.ts
+++ b/meta_configurator/src/components/toolbar/menuItems.ts
@@ -358,16 +358,10 @@ export class MenuItems {
       this.generateToggleButton(
         () => settings.metaSchema.showJsonLdFields,
         () => {
-          getDataForMode(SessionMode.Settings).setDataAt(
-            ['metaSchema', 'showJsonLdFields'],
-            true
-          );
+          getDataForMode(SessionMode.Settings).setDataAt(['metaSchema', 'showJsonLdFields'], true);
         },
         () => {
-          getDataForMode(SessionMode.Settings).setDataAt(
-            ['metaSchema', 'showJsonLdFields'],
-            false
-          );
+          getDataForMode(SessionMode.Settings).setDataAt(['metaSchema', 'showJsonLdFields'], false);
         },
         'fa-solid fa-circle-nodes',
         'fa-solid fa-circle-nodes',
@@ -472,14 +466,17 @@ export class MenuItems {
           panel => panel.panelType === panelTypeName && panel.mode === mode
         ) !== undefined,
       () => {
-        getDataForMode(SessionMode.Settings).setDataAt(['panels', mode], [
-          ...settings.panels[mode],
-          {
-            panelType: panelTypeName,
-            mode,
-            size: 40,
-          },
-        ]);
+        getDataForMode(SessionMode.Settings).setDataAt(
+          ['panels', mode],
+          [
+            ...settings.panels[mode],
+            {
+              panelType: panelTypeName,
+              mode,
+              size: 40,
+            },
+          ]
+        );
       },
       () => {
         getDataForMode(SessionMode.Settings).setDataAt(


### PR DESCRIPTION
**What was done:**

fix settings sync bug

**Why:**

A previous commit (https://github.com/MetaConfigurator/meta-configurator/commit/3c3e5f9fe615573f5418361fecb4663a273a5a1b) made settings reference shallow, but multiple places writing into settings ref were not updated. Hence their writes were not listened to by anyone and features such as toggling views on/off no longer worked. Now, in these places the ManagedData functions to update data are used instead of writing to shallow ref directly. These functions trigger all watchers, solving the issue.